### PR TITLE
Add microphone selection with real-time volume meters

### DIFF
--- a/src/WhisperDesk.Core/Configuration/PipelineConfig.cs
+++ b/src/WhisperDesk.Core/Configuration/PipelineConfig.cs
@@ -23,6 +23,9 @@ public class PipelineConfig
     /// <summary>Enable LLM text cleanup post-processing.</summary>
     public bool EnableTextCleanup { get; set; } = true;
 
+    /// <summary>WASAPI device ID for microphone selection. Empty string = system default.</summary>
+    public string AudioDeviceId { get; set; } = "";
+
     /// <summary>Audio format settings.</summary>
     public AudioFormatConfig Audio { get; set; } = new();
 }

--- a/src/WhisperDesk.Core/Configuration/PipelineServiceRegistration.cs
+++ b/src/WhisperDesk.Core/Configuration/PipelineServiceRegistration.cs
@@ -25,6 +25,9 @@ public static class PipelineServiceRegistration
     {
         services.AddSingleton(pipelineConfig);
 
+        // Audio device enumeration + level metering
+        services.AddSingleton<AudioDeviceService>();
+
         // Audio routing
         services.AddSingleton<AudioRouter>();
 

--- a/src/WhisperDesk.Core/Pipeline/AudioRouter.cs
+++ b/src/WhisperDesk.Core/Pipeline/AudioRouter.cs
@@ -38,7 +38,9 @@ public class AudioRouter : IDisposable
     /// <summary>
     /// Start microphone capture. Audio is buffered until SetSink is called.
     /// </summary>
-    public void Start(AudioFormat format)
+    /// <param name="format">Audio format for capture.</param>
+    /// <param name="deviceNumber">WaveIn device number (0 = system default).</param>
+    public void Start(AudioFormat format, int deviceNumber = 0)
     {
         _sinkReady = false;
         _currentFormat = format;
@@ -51,6 +53,7 @@ public class AudioRouter : IDisposable
 
         _waveIn = new WaveInEvent
         {
+            DeviceNumber = deviceNumber,
             WaveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels),
             BufferMilliseconds = 50
         };

--- a/src/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
+++ b/src/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using WhisperDesk.Core.Configuration;
 using WhisperDesk.Core.Models;
 using WhisperDesk.Core.Providers.Stt;
+using WhisperDesk.Core.Services;
 
 namespace WhisperDesk.Core.Pipeline;
 
@@ -20,6 +21,7 @@ public class StreamingPipeline : IPipelineController, IDisposable
     private readonly IStreamingSttProvider _sttProvider;
     private readonly IEnumerable<IContextProvider> _contextProviders;
     private readonly IReadOnlyList<IPostProcessingStage> _postProcessingStages;
+    private readonly AudioDeviceService _audioDeviceService;
 
     private PipelineState _state = PipelineState.Idle;
     private SessionContextBuilder? _contextBuilder;
@@ -51,6 +53,7 @@ public class StreamingPipeline : IPipelineController, IDisposable
         PipelineConfig config,
         AudioRouter audioRouter,
         IStreamingSttProvider sttProvider,
+        AudioDeviceService audioDeviceService,
         IEnumerable<IContextProvider> contextProviders,
         IEnumerable<IPostProcessingStage> postProcessingStages)
     {
@@ -58,6 +61,7 @@ public class StreamingPipeline : IPipelineController, IDisposable
         _config = config;
         _audioRouter = audioRouter;
         _sttProvider = sttProvider;
+        _audioDeviceService = audioDeviceService;
         _contextProviders = contextProviders;
         _postProcessingStages = postProcessingStages.OrderBy(s => s.Order).ToList();
     }
@@ -91,7 +95,8 @@ public class StreamingPipeline : IPipelineController, IDisposable
                 };
 
                 // 1. Start mic capture IMMEDIATELY (buffered)
-                _audioRouter.Start(audioFormat);
+                var deviceNumber = _audioDeviceService.ResolveWaveInDeviceNumber(_config.AudioDeviceId);
+                _audioRouter.Start(audioFormat, deviceNumber);
 
                 // 2. Prepare context + start STT in parallel
                 _contextBuilder = new SessionContextBuilder();

--- a/src/WhisperDesk.Core/Services/AudioDeviceService.cs
+++ b/src/WhisperDesk.Core/Services/AudioDeviceService.cs
@@ -1,0 +1,170 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace WhisperDesk.Core.Services;
+
+/// <summary>
+/// Information about an audio capture device.
+/// </summary>
+public class AudioDeviceInfo
+{
+    /// <summary>WASAPI MMDevice.ID, stable across reboots.</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Human-readable device name (MMDevice.FriendlyName).</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Whether this is the system default communications capture device.</summary>
+    public bool IsDefault { get; init; }
+}
+
+/// <summary>
+/// Enumerates audio capture devices and reads real-time volume levels via WASAPI.
+/// </summary>
+public class AudioDeviceService : IDisposable
+{
+    private readonly MMDeviceEnumerator _enumerator = new();
+    private readonly Dictionary<string, MMDevice> _openDevices = new();
+    private readonly List<WasapiCapture> _monitorCaptures = new();
+
+    /// <summary>Get all active capture (microphone) devices.</summary>
+    public List<AudioDeviceInfo> GetCaptureDevices()
+    {
+        string? defaultId = null;
+        try
+        {
+            var defaultDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+            defaultId = defaultDevice.ID;
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // No default capture device available
+        }
+
+        var devices = _enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+        return devices.Select(d => new AudioDeviceInfo
+        {
+            Id = d.ID,
+            Name = d.FriendlyName,
+            IsDefault = defaultId != null && d.ID == defaultId
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Get the current peak volume (0.0-1.0) for a device by its WASAPI ID.
+    /// Reads from the Windows audio mixer -- zero overhead, no recording needed.
+    /// Keeps MMDevice handles open for accurate continuous reads.
+    /// Returns 0 if device not found or on error.
+    /// </summary>
+    public float GetPeakVolume(string deviceId)
+    {
+        try
+        {
+            if (!_openDevices.TryGetValue(deviceId, out var device))
+            {
+                device = _enumerator.GetDevice(deviceId);
+                _openDevices[deviceId] = device;
+            }
+            return device.AudioMeterInformation.MasterPeakValue;
+        }
+        catch
+        {
+            _openDevices.Remove(deviceId);
+            return 0f;
+        }
+    }
+
+    /// <summary>
+    /// Start silent capture streams on all devices so that MasterPeakValue
+    /// returns live data. Some drivers only report peak values when an active
+    /// audio stream exists on the device.
+    /// Call StopMonitoring() when volume display is no longer needed.
+    /// </summary>
+    public void StartMonitoring()
+    {
+        StopMonitoring();
+
+        var devices = _enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+        foreach (var device in devices)
+        {
+            try
+            {
+                var capture = new WasapiCapture(device) { ShareMode = AudioClientShareMode.Shared };
+                capture.DataAvailable += (_, _) => { }; // discard audio data
+                capture.StartRecording();
+                _monitorCaptures.Add(capture);
+            }
+            catch
+            {
+                // Device may not support shared mode capture — skip it
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stop all monitoring capture streams.
+    /// </summary>
+    public void StopMonitoring()
+    {
+        foreach (var capture in _monitorCaptures)
+        {
+            try
+            {
+                capture.StopRecording();
+                capture.Dispose();
+            }
+            catch { }
+        }
+        _monitorCaptures.Clear();
+    }
+
+    /// <summary>
+    /// Release cached device handles. Call when volume monitoring is no longer needed.
+    /// </summary>
+    public void ReleaseCachedDevices()
+    {
+        foreach (var device in _openDevices.Values)
+        {
+            try { device.Dispose(); } catch { }
+        }
+        _openDevices.Clear();
+    }
+
+    /// <summary>
+    /// Resolve a WASAPI device ID to a WaveIn device number.
+    /// WaveIn uses a separate device numbering system, so we match by name.
+    /// Returns 0 (default device) if the ID cannot be resolved.
+    /// </summary>
+    public int ResolveWaveInDeviceNumber(string? deviceId)
+    {
+        if (string.IsNullOrEmpty(deviceId)) return 0;
+
+        try
+        {
+            using var mmDevice = _enumerator.GetDevice(deviceId);
+            var targetName = mmDevice.FriendlyName;
+
+            for (int i = 0; i < WaveInEvent.DeviceCount; i++)
+            {
+                var caps = WaveInEvent.GetCapabilities(i);
+                // WaveIn ProductName is truncated to 31 chars
+                if (targetName.StartsWith(caps.ProductName.TrimEnd('\0')))
+                    return i;
+            }
+        }
+        catch
+        {
+            // Device may have been disconnected
+        }
+
+        return 0; // fallback to default
+    }
+
+    public void Dispose()
+    {
+        StopMonitoring();
+        ReleaseCachedDevices();
+        _enumerator.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/WhisperDesk/App.xaml.cs
+++ b/src/WhisperDesk/App.xaml.cs
@@ -114,6 +114,7 @@ public partial class App : Application
             LlmProvider = settings.Transcription.CleanupProvider,
             Language = settings.Transcription.Language,
             EnableTextCleanup = true,
+            AudioDeviceId = settings.Audio.DeviceId,
             Audio = new AudioFormatConfig
             {
                 SampleRate = settings.Audio.SampleRate,

--- a/src/WhisperDesk/Models/WhisperDeskSettings.cs
+++ b/src/WhisperDesk/Models/WhisperDeskSettings.cs
@@ -37,6 +37,9 @@ public class AudioSettings
     public int SampleRate { get; set; } = 16000;
     public int Channels { get; set; } = 1;
     public int BitsPerSample { get; set; } = 16;
+
+    /// <summary>WASAPI device ID for microphone selection. Empty string = system default.</summary>
+    public string DeviceId { get; set; } = "";
 }
 
 public class TranscriptionSettings

--- a/src/WhisperDesk/ViewModels/MainViewModel.cs
+++ b/src/WhisperDesk/ViewModels/MainViewModel.cs
@@ -1,8 +1,11 @@
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MaterialDesignThemes.Wpf;
+using WhisperDesk.Core.Configuration;
 using WhisperDesk.Core.Pipeline;
 using WhisperDesk.Core.Models;
 using WhisperDesk.Core.Services;
@@ -21,6 +24,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly ClipboardPasteService _pasteService;
     private readonly TranscriptionLogService _logService;
     private readonly RecordingSettings _recordingSettings;
+    private readonly AudioDeviceService _audioDeviceService;
+    private readonly PipelineConfig _pipelineConfig;
+    private readonly WhisperDeskSettings _appSettings;
     private readonly ILoggerFactory _loggerFactory;
     private CancellationTokenSource? _cts;
     private bool _isStopping;
@@ -65,7 +71,10 @@ public partial class MainViewModel : ObservableObject, IDisposable
         HotkeyService hotkeyService,
         ClipboardPasteService pasteService,
         TranscriptionLogService logService,
-        RecordingSettings recordingSettings)
+        RecordingSettings recordingSettings,
+        AudioDeviceService audioDeviceService,
+        PipelineConfig pipelineConfig,
+        WhisperDeskSettings appSettings)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
@@ -74,6 +83,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _pasteService = pasteService;
         _logService = logService;
         _recordingSettings = recordingSettings;
+        _audioDeviceService = audioDeviceService;
+        _pipelineConfig = pipelineConfig;
+        _appSettings = appSettings;
 
         IsSaveRecordingVisible = !string.IsNullOrWhiteSpace(_recordingSettings.SavePath);
 
@@ -292,6 +304,81 @@ public partial class MainViewModel : ObservableObject, IDisposable
             _logger.LogError(ex, "[ViewModel] Failed to open eval dialog");
             LastError = $"Failed to open eval dialog: {ex.Message}";
             HasError = true;
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenSettings()
+    {
+        try
+        {
+            var settingsVm = new SettingsViewModel(_audioDeviceService, _pipelineConfig.AudioDeviceId);
+            var settingsDialog = new SettingsDialog { DataContext = settingsVm };
+
+            try
+            {
+                await DialogHost.Show(settingsDialog, "RootDialog");
+
+                if (settingsVm.Applied && settingsVm.SelectedDeviceId != null)
+                {
+                    var newDeviceId = settingsVm.SelectedDeviceId;
+                    _logger.LogInformation("[ViewModel] Settings applied. Device: {DeviceId}", newDeviceId);
+
+                    // Update in-memory config so next recording session uses the new device
+                    _pipelineConfig.AudioDeviceId = newDeviceId;
+                    _appSettings.Audio.DeviceId = newDeviceId;
+
+                    // Persist to appsettings.json
+                    SaveDeviceIdToSettings(newDeviceId);
+                }
+            }
+            finally
+            {
+                settingsVm.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[ViewModel] Failed to open settings dialog");
+            LastError = $"Failed to open settings: {ex.Message}";
+            HasError = true;
+        }
+    }
+
+    private void SaveDeviceIdToSettings(string deviceId)
+    {
+        try
+        {
+            var exeDir = Path.GetDirectoryName(Environment.ProcessPath
+                ?? System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName)!;
+            var settingsPath = Path.Combine(exeDir, "appsettings.json");
+
+            if (!File.Exists(settingsPath))
+            {
+                _logger.LogWarning("[ViewModel] appsettings.json not found at {Path}", settingsPath);
+                return;
+            }
+
+            var json = File.ReadAllText(settingsPath);
+            var doc = JsonNode.Parse(json, documentOptions: new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip })
+                      ?? new JsonObject();
+
+            // Ensure Audio section exists
+            if (doc["Audio"] is not JsonObject audioNode)
+            {
+                audioNode = new JsonObject();
+                doc["Audio"] = audioNode;
+            }
+            audioNode["DeviceId"] = deviceId;
+
+            var writeOptions = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(settingsPath, doc.ToJsonString(writeOptions));
+
+            _logger.LogInformation("[ViewModel] Saved DeviceId to appsettings.json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[ViewModel] Failed to save settings to appsettings.json");
         }
     }
 

--- a/src/WhisperDesk/ViewModels/SettingsViewModel.cs
+++ b/src/WhisperDesk/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,115 @@
+using System.Collections.ObjectModel;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MaterialDesignThemes.Wpf;
+using WhisperDesk.Core.Services;
+
+namespace WhisperDesk.ViewModels;
+
+/// <summary>
+/// ViewModel for the Settings dialog. Shows available microphones with
+/// real-time volume meters and lets the user pick one.
+/// </summary>
+public partial class SettingsViewModel : ObservableObject, IDisposable
+{
+    private readonly AudioDeviceService _deviceService;
+    private readonly DispatcherTimer _volumeTimer;
+
+    public ObservableCollection<MicrophoneItem> Devices { get; } = new();
+
+    [ObservableProperty]
+    private bool _noDevicesFound;
+
+    /// <summary>The WASAPI device ID of the currently selected mic, or null if none selected.</summary>
+    public string? SelectedDeviceId => Devices.FirstOrDefault(d => d.IsSelected)?.Id;
+
+    /// <summary>True when Apply was clicked (signals the caller to save).</summary>
+    public bool Applied { get; private set; }
+
+    public SettingsViewModel(AudioDeviceService deviceService, string currentDeviceId)
+    {
+        _deviceService = deviceService;
+
+        LoadDevices(currentDeviceId);
+
+        // Start silent capture streams so MasterPeakValue reports live data
+        _deviceService.StartMonitoring();
+
+        // Poll volume levels every 50ms while the dialog is open
+        _volumeTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
+        _volumeTimer.Tick += (_, _) => UpdateVolumes();
+        _volumeTimer.Start();
+    }
+
+    private void LoadDevices(string currentDeviceId)
+    {
+        var devices = _deviceService.GetCaptureDevices();
+        NoDevicesFound = devices.Count == 0;
+
+        foreach (var d in devices)
+        {
+            bool shouldSelect = !string.IsNullOrEmpty(currentDeviceId)
+                ? d.Id == currentDeviceId
+                : d.IsDefault;
+
+            var item = new MicrophoneItem
+            {
+                Id = d.Id,
+                DisplayName = d.IsDefault ? $"{d.Name} (Default)" : d.Name,
+                IsSelected = shouldSelect
+            };
+            Devices.Add(item);
+        }
+
+        // If nothing was selected (e.g., saved device was disconnected), select the first/default
+        if (Devices.Count > 0 && !Devices.Any(d => d.IsSelected))
+        {
+            Devices[0].IsSelected = true;
+        }
+    }
+
+    private void UpdateVolumes()
+    {
+        foreach (var device in Devices)
+        {
+            var peak = _deviceService.GetPeakVolume(device.Id);
+            device.Volume = (int)(peak * 100);
+        }
+    }
+
+    [RelayCommand]
+    private void Apply()
+    {
+        Applied = true;
+        // Close the MaterialDesign DialogHost with "true" result
+        DialogHost.CloseDialogCommand.Execute(true, null);
+    }
+
+    public void Dispose()
+    {
+        _volumeTimer.Stop();
+        _deviceService.StopMonitoring();
+        _deviceService.ReleaseCachedDevices();
+        GC.SuppressFinalize(this);
+    }
+}
+
+/// <summary>
+/// Represents a single microphone device in the Settings dialog device list.
+/// </summary>
+public partial class MicrophoneItem : ObservableObject
+{
+    /// <summary>WASAPI device ID.</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Display name (may include "(Default)" suffix).</summary>
+    public string DisplayName { get; init; } = "";
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    /// <summary>Current volume level 0-100 for the progress bar.</summary>
+    [ObservableProperty]
+    private int _volume;
+}

--- a/src/WhisperDesk/Views/MainWindow.xaml
+++ b/src/WhisperDesk/Views/MainWindow.xaml
@@ -42,6 +42,14 @@
                                              Width="28" Height="28"
                                              VerticalAlignment="Center"
                                              Margin="0,0,12,0" />
+                    <!-- Settings button (right-aligned) -->
+                    <Button DockPanel.Dock="Right"
+                            Style="{StaticResource MaterialDesignIconForegroundButton}"
+                            ToolTip="Settings"
+                            Command="{Binding OpenSettingsCommand}"
+                            VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="Cog" Width="22" Height="22" />
+                    </Button>
                     <StackPanel>
                         <TextBlock Text="WhisperDesk"
                                    Style="{StaticResource MaterialDesignHeadline6TextBlock}" />

--- a/src/WhisperDesk/Views/SettingsDialog.xaml
+++ b/src/WhisperDesk/Views/SettingsDialog.xaml
@@ -1,0 +1,117 @@
+<UserControl x:Class="WhisperDesk.Views.SettingsDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:local="clr-namespace:WhisperDesk.Views"
+             MinWidth="500" MaxWidth="640"
+             Margin="16">
+
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <local:VolumeToWidthConverter x:Key="VolumeToWidthConverter" />
+    </UserControl.Resources>
+
+    <StackPanel>
+        <!-- Header -->
+        <DockPanel Margin="0,0,0,16">
+            <materialDesign:PackIcon Kind="Cog"
+                                     Width="28" Height="28"
+                                     VerticalAlignment="Center"
+                                     Margin="0,0,12,0"
+                                     Foreground="{DynamicResource PrimaryHueMidBrush}" />
+            <StackPanel>
+                <TextBlock Text="Settings"
+                           Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
+                <TextBlock Text="Configure microphone and audio devices"
+                           Style="{StaticResource MaterialDesignCaptionTextBlock}"
+                           Opacity="0.6" />
+            </StackPanel>
+        </DockPanel>
+
+        <!-- Microphone Section -->
+        <TextBlock Text="Microphone"
+                   Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                   Foreground="{DynamicResource PrimaryHueMidBrush}"
+                   Margin="0,0,0,8" />
+
+        <TextBlock Text="Select a microphone. Volume bars show real-time input levels."
+                   Style="{StaticResource MaterialDesignCaptionTextBlock}"
+                   Opacity="0.5"
+                   Margin="0,0,0,12" />
+
+        <!-- Device List -->
+        <ItemsControl ItemsSource="{Binding Devices}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <materialDesign:Card UniformCornerRadius="8"
+                                         Padding="12,10"
+                                         Margin="0,0,0,6">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="120" />
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Radio button for selection -->
+                            <RadioButton Grid.Column="0"
+                                         IsChecked="{Binding IsSelected}"
+                                         GroupName="MicrophoneSelection"
+                                         VerticalAlignment="Center"
+                                         Margin="0,0,12,0" />
+
+                            <!-- Device name -->
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding DisplayName}"
+                                       Style="{StaticResource MaterialDesignBody2TextBlock}"
+                                       VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis" />
+
+                            <!-- Volume meter bar -->
+                            <Grid Grid.Column="2"
+                                  Height="8"
+                                  VerticalAlignment="Center"
+                                  Margin="12,0,0,0">
+                                <!-- Background track -->
+                                <Border Background="#E0E0E0" CornerRadius="4" />
+                                <!-- Filled portion, width bound to Volume (0-100%) -->
+                                <Border Background="#4CAF50" CornerRadius="4"
+                                        HorizontalAlignment="Left">
+                                    <Border.Width>
+                                        <MultiBinding Converter="{StaticResource VolumeToWidthConverter}">
+                                            <Binding Path="Volume" />
+                                            <Binding Path="ActualWidth"
+                                                     RelativeSource="{RelativeSource AncestorType=Grid}" />
+                                        </MultiBinding>
+                                    </Border.Width>
+                                </Border>
+                            </Grid>
+                        </Grid>
+                    </materialDesign:Card>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <!-- No devices warning -->
+        <TextBlock Text="No microphones detected."
+                   Style="{StaticResource MaterialDesignBody2TextBlock}"
+                   Opacity="0.5"
+                   Margin="0,8,0,0"
+                   Visibility="{Binding NoDevicesFound, Converter={StaticResource BoolToVis}}" />
+
+        <!-- Buttons -->
+        <DockPanel Margin="0,20,0,0">
+            <Button DockPanel.Dock="Right"
+                    Style="{StaticResource MaterialDesignFlatButton}"
+                    Content="CANCEL"
+                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                    CommandParameter="false"
+                    Margin="8,0,0,0" />
+            <Button DockPanel.Dock="Right"
+                    Style="{StaticResource MaterialDesignRaisedButton}"
+                    Content="APPLY"
+                    Command="{Binding ApplyCommand}" />
+            <StackPanel /> <!-- Spacer -->
+        </DockPanel>
+    </StackPanel>
+</UserControl>

--- a/src/WhisperDesk/Views/SettingsDialog.xaml.cs
+++ b/src/WhisperDesk/Views/SettingsDialog.xaml.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace WhisperDesk.Views;
+
+public partial class SettingsDialog : UserControl
+{
+    public SettingsDialog()
+    {
+        InitializeComponent();
+    }
+}
+
+/// <summary>
+/// Converts a volume percentage (0-100) and a container width to a pixel width.
+/// Used for the custom volume meter bar.
+/// </summary>
+public class VolumeToWidthConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 2
+            && values[0] is int volume
+            && values[1] is double containerWidth
+            && containerWidth > 0)
+        {
+            return Math.Max(0, Math.Min(containerWidth, containerWidth * volume / 100.0));
+        }
+        return 0.0;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/WhisperDesk/appsettings.json
+++ b/src/WhisperDesk/appsettings.json
@@ -21,7 +21,8 @@
   "Audio": {
     "SampleRate": 16000,
     "Channels": 1,
-    "BitsPerSample": 16
+    "BitsPerSample": 16,
+    "DeviceId": ""
   },
   "Transcription": {
     "SpeechProvider": "Volcengine",


### PR DESCRIPTION
## Summary
- Add Settings dialog (gear icon in main window) with microphone device picker
- All capture devices listed with real-time volume meter bars (WASAPI `AudioMeterInformation.MasterPeakValue`)
- Silent `WasapiCapture` streams activate while dialog is open for accurate volume readings
- Selected device ID persists to `appsettings.json` under `Audio.DeviceId`
- Device selection takes effect on next F9 recording session

## New files
- `AudioDeviceService.cs` — WASAPI device enumeration, peak volume reading, monitoring streams
- `SettingsDialog.xaml` + `.xaml.cs` — MaterialDesign dialog with RadioButton device list + volume bars
- `SettingsViewModel.cs` — MVVM ViewModel with 50ms volume polling timer

## Modified files
- `PipelineConfig.cs` — Added `AudioDeviceId` property
- `AudioRouter.cs` — `Start()` accepts `deviceNumber` parameter
- `StreamingPipeline.cs` — Resolves device ID to WaveIn device number before recording
- `PipelineServiceRegistration.cs` — Registers `AudioDeviceService`
- `MainViewModel.cs` — `OpenSettingsCommand` with save-to-appsettings logic
- `MainWindow.xaml` — Settings gear button in title bar
- `WhisperDeskSettings.cs` — `DeviceId` in `AudioSettings`
- `appsettings.json` — `DeviceId` field under `Audio`
- `App.xaml.cs` — Maps `DeviceId` to pipeline config

## Test plan
- [x] Build succeeds (0 errors, 0 warnings)
- [x] Settings dialog opens with all microphones listed
- [x] Volume bars respond in real-time when speaking into each mic
- [x] Selecting a mic and clicking Apply persists to appsettings.json
- [x] Next F9 recording uses the selected microphone
- [x] Default behavior preserved when DeviceId is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)