### PR TITLE
Suppress Alt menu activation and improve clipboard reliability

### DIFF
--- a/src/WhisperDesk/Services/HotkeyService.cs
+++ b/src/WhisperDesk/Services/HotkeyService.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using H.Hooks;
 using WhisperDesk.Models;
 using Microsoft.Extensions.Logging;
@@ -29,7 +28,13 @@ public class HotkeyService : IDisposable
     {
         _keyboardHook = new LowLevelKeyboardHook
         {
-            HandleModifierKeys = true
+            HandleModifierKeys = true,
+            // Handling=true makes event dispatch synchronous on the hook thread,
+            // so e.IsHandled=true causes the hook to return LRESULT(-1) and
+            // actually suppress the keystroke before it reaches the message queue.
+            // Without this, H.Hooks dispatches events via ThreadPool (async) and
+            // reads IsHandled immediately after, always seeing false.
+            Handling = true
         };
         _keyboardHook.Down += OnKeyDown;
         _keyboardHook.Up += OnKeyUp;
@@ -50,13 +55,23 @@ public class HotkeyService : IDisposable
         if (!_pushToTalkActive && IsHotkeyPressed(_settings.PushToTalk))
         {
             _pushToTalkActive = true;
+            e.IsHandled = true;
             _logger.LogDebug("Push-to-talk activated");
             PushToTalkPressed?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        // While push-to-talk is held, swallow repeat events for the PTT key
+        if (_pushToTalkActive && ContainsPushToTalkKey(e))
+        {
+            e.IsHandled = true;
+            return;
         }
 
         // Check paste hotkey
         if (IsHotkeyPressed(_settings.PasteTranscription))
         {
+            e.IsHandled = true;
             _logger.LogDebug("Paste hotkey activated");
             PasteHotkeyPressed?.Invoke(this, EventArgs.Empty);
         }
@@ -64,6 +79,8 @@ public class HotkeyService : IDisposable
 
     private void OnKeyUp(object? sender, KeyboardEventArgs e)
     {
+        bool containsPttKey = ContainsPushToTalkKey(e);
+
         foreach (var key in e.Keys.Values)
         {
             _pressedKeys.Remove(key);
@@ -73,9 +90,52 @@ public class HotkeyService : IDisposable
         if (_pushToTalkActive && !IsHotkeyPressed(_settings.PushToTalk))
         {
             _pushToTalkActive = false;
+            e.IsHandled = true;
             _logger.LogDebug("Push-to-talk released");
             PushToTalkReleased?.Invoke(this, EventArgs.Empty);
+            return;
         }
+
+        // Swallow any PTT-related key release while PTT is still active
+        if (_pushToTalkActive && containsPttKey)
+        {
+            e.IsHandled = true;
+        }
+    }
+
+    /// <summary>
+    /// Check if the keyboard event contains any key that is part of the push-to-talk hotkey.
+    /// </summary>
+    private bool ContainsPushToTalkKey(KeyboardEventArgs e)
+    {
+        var pttParts = _settings.PushToTalk.Split('+').Select(p => p.Trim().ToLowerInvariant());
+        foreach (var part in pttParts)
+        {
+            HKey? targetKey = part switch
+            {
+                "ctrl" or "control" => HKey.Ctrl,
+                "lctrl" or "leftctrl" => HKey.LeftCtrl,
+                "rctrl" or "rightctrl" => HKey.RightCtrl,
+                "shift" => HKey.Shift,
+                "lshift" or "leftshift" => HKey.LeftShift,
+                "rshift" or "rightshift" => HKey.RightShift,
+                "alt" => HKey.Alt,
+                "lalt" or "leftalt" => HKey.LeftAlt,
+                "ralt" or "rightalt" => HKey.RightAlt,
+                _ => Enum.TryParse<HKey>(part, true, out var k) ? k : null
+            };
+
+            if (targetKey == null) continue;
+
+            foreach (var eventKey in e.Keys.Values)
+            {
+                if (eventKey == targetKey.Value) return true;
+                if (targetKey.Value == HKey.RightAlt && (eventKey == HKey.Alt || eventKey == HKey.RightAlt)) return true;
+                if (targetKey.Value == HKey.LeftAlt && (eventKey == HKey.Alt || eventKey == HKey.LeftAlt)) return true;
+                if (targetKey.Value == HKey.Alt && (eventKey == HKey.Alt || eventKey == HKey.LeftAlt || eventKey == HKey.RightAlt)) return true;
+            }
+        }
+        return false;
     }
 
     private bool IsHotkeyPressed(string hotkeyString)
@@ -87,14 +147,19 @@ public class HotkeyService : IDisposable
             var key = part.ToLowerInvariant() switch
             {
                 "ctrl" or "control" => HKey.Ctrl,
+                "lctrl" or "leftctrl" => HKey.LeftCtrl,
+                "rctrl" or "rightctrl" => HKey.RightCtrl,
                 "shift" => HKey.Shift,
+                "lshift" or "leftshift" => HKey.LeftShift,
+                "rshift" or "rightshift" => HKey.RightShift,
                 "alt" => HKey.Alt,
+                "lalt" or "leftalt" => HKey.LeftAlt,
+                "ralt" or "rightalt" => HKey.RightAlt,
                 _ => Enum.TryParse<HKey>(part, true, out var k) ? k : (HKey?)null
             };
 
             if (key == null) return false;
 
-            // For modifier keys, check both left and right variants
             bool isPressed = key.Value switch
             {
                 HKey.Ctrl => _pressedKeys.Contains(HKey.Ctrl) || _pressedKeys.Contains(HKey.LeftCtrl) || _pressedKeys.Contains(HKey.RightCtrl),

--- a/src/WhisperDesk/ViewModels/MainViewModel.cs
+++ b/src/WhisperDesk/ViewModels/MainViewModel.cs
@@ -124,42 +124,50 @@ public partial class MainViewModel : ObservableObject, IDisposable
             PartialText = string.Empty;
             CanSaveRecording = IsSaveRecordingVisible && _pipeline.HasRecordingData;
 
-            // Write to clipboard with retries, then paste sequentially
+            // Write to clipboard and paste — run off UI thread to avoid blocking animations
             if (!string.IsNullOrEmpty(result.ProcessedText))
             {
-                bool clipboardOk = false;
-                for (int i = 0; i < 5; i++)
+                var textToPaste = result.ProcessedText;
+                _ = Task.Run(async () =>
                 {
-                    try
+                    // Write to clipboard with retries (must be on STA thread)
+                    bool clipboardOk = false;
+                    var staThread = new Thread(() =>
                     {
-                        Clipboard.SetDataObject(result.ProcessedText, true);
-                        clipboardOk = true;
-                        _logger.LogInformation("[ViewModel] Cleaned text copied to clipboard.");
-                        break;
-                    }
-                    catch (System.Runtime.InteropServices.COMException ex)
-                    {
-                        _logger.LogWarning("[ViewModel] Clipboard busy (attempt {Attempt}/5): {Message}", i + 1, ex.Message);
-                        if (i < 4) Thread.Sleep(100);
-                    }
-                }
+                        for (int i = 0; i < 5; i++)
+                        {
+                            try
+                            {
+                                Clipboard.SetDataObject(textToPaste, true);
+                                clipboardOk = true;
+                                _logger.LogInformation("[ViewModel] Cleaned text copied to clipboard.");
+                                break;
+                            }
+                            catch (System.Runtime.InteropServices.COMException ex)
+                            {
+                                _logger.LogWarning("[ViewModel] Clipboard busy (attempt {Attempt}/5): {Message}", i + 1, ex.Message);
+                                if (i < 4) Thread.Sleep(100);
+                            }
+                        }
+                    });
+                    staThread.SetApartmentState(ApartmentState.STA);
+                    staThread.Start();
+                    staThread.Join();
 
-                if (clipboardOk)
-                {
-                    // Paste AFTER clipboard write succeeds — sequential, no race
-                    _ = Task.Run(async () =>
+                    if (clipboardOk)
                     {
-                        await Task.Delay(150); // let clipboard settle + let hotkey keys release
+                        // Wait for RDP clipboard sync before pasting
+                        await Task.Delay(500);
                         Application.Current?.Dispatcher.InvokeAsync(() =>
                         {
                             _pasteService.PasteToActiveWindow();
                         });
-                    });
-                }
-                else
-                {
-                    _logger.LogWarning("[ViewModel] Clipboard unavailable after retries, skipping auto-paste.");
-                }
+                    }
+                    else
+                    {
+                        _logger.LogWarning("[ViewModel] Clipboard unavailable after retries, skipping auto-paste.");
+                    }
+                });
             }
         });
 

--- a/src/WhisperDesk/Views/MainWindow.xaml.cs
+++ b/src/WhisperDesk/Views/MainWindow.xaml.cs
@@ -26,6 +26,32 @@ public partial class MainWindow : Window
         }
     }
 
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+
+        // Intercept WM_SYSCOMMAND SC_KEYMENU at the Win32 message level.
+        // This suppresses menu-bar activation triggered by bare Alt press/release,
+        // which WPF (via ComponentDispatcher) and DefWindowProc can generate even
+        // when the low-level keyboard hook has already marked the Alt keys as handled.
+        var source = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+        source?.AddHook(WndProc);
+    }
+
+    private const int WM_SYSCOMMAND = 0x0112;
+    private const int SC_KEYMENU = 0xF100;
+
+    private static IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        // SC_KEYMENU with lParam==0 is a keyboard-triggered menu activation (bare Alt key).
+        // Masking wParam with 0xFFF0 normalizes the value per the Win32 spec.
+        if (msg == WM_SYSCOMMAND && (wParam.ToInt32() & 0xFFF0) == SC_KEYMENU)
+        {
+            handled = true;
+        }
+        return IntPtr.Zero;
+    }
+
     private void Window_StateChanged(object sender, EventArgs e)
     {
         if (WindowState == WindowState.Minimized)

--- a/src/WhisperDesk/appsettings.json
+++ b/src/WhisperDesk/appsettings.json
@@ -15,7 +15,7 @@
     "ResourceId": "volc.seedasr.sauc.duration"
   },
   "Hotkeys": {
-    "PushToTalk": "F9",
+    "PushToTalk": "RightAlt",
     "PasteTranscription": "Ctrl+Shift+V"
   },
   "Audio": {


### PR DESCRIPTION
## Summary
- Fix Right Alt triggering menu bar activation in foreground apps (Notepad, VS Code, etc.)
- Support left/right-specific modifier keys in hotkey configuration (`RightAlt`, `LeftCtrl`, etc.)
- Move clipboard write off UI thread to prevent animation stutter during "Polishing" phase
- Increase paste delay for RDP clipboard sync compatibility

## Root Cause: Alt Menu Activation
H.Hooks' `Handling` property defaults to `false`, dispatching events via ThreadPool async. This made `e.IsHandled = true` a no-op — the hook callback returned before the handler ran. Setting `Handling = true` makes dispatch synchronous, so the hook returns `LRESULT(-1)` and actually suppresses the keystroke.

Additionally, WPF has its own internal keyboard processing path that can trigger menu mode independently. A `WndProc` hook intercepts `WM_SYSCOMMAND SC_KEYMENU` as defense-in-depth.

## Changes (4 files)
- **`HotkeyService.cs`** — `Handling=true`, left/right modifier support, PTT key event swallowing
- **`MainWindow.xaml.cs`** — `WM_SYSCOMMAND SC_KEYMENU` interception via `HwndSource.AddHook`
- **`MainViewModel.cs`** — Clipboard write moved to background STA thread with 5x retry; paste delay increased to 500ms
- **`appsettings.json`** — Default push-to-talk changed to `RightAlt`

## Test plan
- [x] Build succeeds (0 errors)
- [x] Right Alt press/release does NOT activate menu bar in Notepad, VS Code, etc.
- [x] Push-to-talk works with RightAlt: press to record, release to stop
- [x] Clipboard paste works after transcription completes
- [x] "Polishing" overlay animation no longer stutters
- [ ] Verify RDP Dev Box paste reliability with 500ms delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)