### PR TITLE
Centralize build props and package versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup Label="Module paths">
+    <SrcRoot>$(MSBuildThisFileDirectory)src\</SrcRoot>
+    <SttRoot>$(SrcRoot)stt\</SttRoot>
+    <LlmRoot>$(SrcRoot)llm\</LlmRoot>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- Redirect build artifacts to repo-level build/ directory.
          Required for WPF projects in flattened directories (src/, tests/)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Redirect build artifacts to repo-level build/ directory.
          Required for WPF projects in flattened directories (src/, tests/)
          to prevent temp project from scanning obj/ generated files. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,45 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup Label="Microsoft.Extensions">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="UI">
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageVersion Include="MaterialDesignThemes" Version="5.1.0" />
+    <PackageVersion Include="MaterialDesignColors" Version="3.1.0" />
+    <PackageVersion Include="H.Hooks" Version="1.4.3" />
+    <PackageVersion Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Audio">
+    <PackageVersion Include="NAudio" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="AI / Speech">
+    <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.42.0" />
+    <PackageVersion Include="OpenAI" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Serialization">
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+</Project>

--- a/src/WhisperDesk.Core/WhisperDesk.Core.csproj
+++ b/src/WhisperDesk.Core/WhisperDesk.Core.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\stt\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
-    <ProjectReference Include="..\llm\WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
+    <ProjectReference Include="$(SttRoot)WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
+    <ProjectReference Include="$(LlmRoot)WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WhisperDesk.Core/WhisperDesk.Core.csproj
+++ b/src/WhisperDesk.Core/WhisperDesk.Core.csproj
@@ -1,19 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Core</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\stt\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
     <ProjectReference Include="..\llm\WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="NAudio" />
   </ItemGroup>
 </Project>

--- a/src/WhisperDesk/WhisperDesk.csproj
+++ b/src/WhisperDesk/WhisperDesk.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>WhisperDesk</AssemblyName>
@@ -14,63 +12,29 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <!-- ============================================================
-       Publish configuration: self-contained, single-file executable
-       Run: dotnet publish -c Release  (or use build-release.ps1)
-       ============================================================ -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <!-- Self-contained: bundle .NET runtime so users don't need to install it -->
     <SelfContained>true</SelfContained>
-
-    <!-- Single-file: pack managed assemblies into one exe -->
     <PublishSingleFile>true</PublishSingleFile>
-
-    <!-- Include native DLLs inside the single exe (extracted at first run) -->
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-
-    <!-- Include all content in the single file by default -->
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
-
-    <!-- ReadyToRun: ahead-of-time compilation for faster startup -->
     <PublishReadyToRun>true</PublishReadyToRun>
-
-    <!--
-      Trimming: WPF, DI, MaterialDesign, and Azure SDK rely heavily on reflection.
-      Full trimming breaks them. Disable trimming to keep things reliable.
-      Trade-off: ~30-50 MB larger, but zero runtime surprises.
-    -->
     <PublishTrimmed>false</PublishTrimmed>
-
-    <!-- Compress the single-file bundle for smaller download -->
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Audio recording (needed directly for EvalDialogViewModel playback) -->
-    <PackageReference Include="NAudio" Version="2.2.1" />
-
-    <!-- MVVM framework -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-
-    <!-- Material Design UI -->
-    <PackageReference Include="MaterialDesignThemes" Version="5.1.0" />
-    <PackageReference Include="MaterialDesignColors" Version="3.1.0" />
-
-    <!-- Dependency injection -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-
-    <!-- JSON -->
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-
-    <!-- Global hotkeys -->
-    <PackageReference Include="H.Hooks" Version="1.4.3" />
-
-    <!-- Hardcodet NotifyIcon for system tray -->
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
+    <PackageReference Include="NAudio" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="MaterialDesignThemes" />
+    <PackageReference Include="MaterialDesignColors" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="H.Hooks" />
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" />
   </ItemGroup>
 
   <ItemGroup>
@@ -80,7 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- appsettings.json: EXCLUDED from single-file so users can edit it alongside the exe -->
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
@@ -93,7 +56,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </None>
-    <!-- App icon: embedded as WPF Resource so it works in single-file publish -->
     <Resource Include="Assets\app.ico" />
   </ItemGroup>
 

--- a/src/WhisperDesk/WhisperDesk.csproj
+++ b/src/WhisperDesk/WhisperDesk.csproj
@@ -38,9 +38,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WhisperDesk.Core\WhisperDesk.Core.csproj" />
-    <ProjectReference Include="..\stt\WhisperDesk.Stt\WhisperDesk.Stt.csproj" />
-    <ProjectReference Include="..\llm\WhisperDesk.Llm\WhisperDesk.Llm.csproj" />
+    <ProjectReference Include="$(SrcRoot)WhisperDesk.Core\WhisperDesk.Core.csproj" />
+    <ProjectReference Include="$(SttRoot)WhisperDesk.Stt\WhisperDesk.Stt.csproj" />
+    <ProjectReference Include="$(LlmRoot)WhisperDesk.Llm\WhisperDesk.Llm.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/llm/WhisperDesk.Llm.Contract/WhisperDesk.Llm.Contract.csproj
+++ b/src/llm/WhisperDesk.Llm.Contract/WhisperDesk.Llm.Contract.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Llm.Contract</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/src/llm/WhisperDesk.Llm/WhisperDesk.Llm.csproj
+++ b/src/llm/WhisperDesk.Llm/WhisperDesk.Llm.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Llm</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
     <ProjectReference Include="..\providers\WhisperDesk.Llm.Provider.AzureOpenAI\WhisperDesk.Llm.Provider.AzureOpenAI.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/llm/WhisperDesk.Llm/WhisperDesk.Llm.csproj
+++ b/src/llm/WhisperDesk.Llm/WhisperDesk.Llm.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
-    <ProjectReference Include="..\providers\WhisperDesk.Llm.Provider.AzureOpenAI\WhisperDesk.Llm.Provider.AzureOpenAI.csproj" />
+    <ProjectReference Include="$(LlmRoot)WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
+    <ProjectReference Include="$(LlmRoot)providers\WhisperDesk.Llm.Provider.AzureOpenAI\WhisperDesk.Llm.Provider.AzureOpenAI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/llm/providers/WhisperDesk.Llm.Provider.AzureOpenAI/WhisperDesk.Llm.Provider.AzureOpenAI.csproj
+++ b/src/llm/providers/WhisperDesk.Llm.Provider.AzureOpenAI/WhisperDesk.Llm.Provider.AzureOpenAI.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Llm.Provider.AzureOpenAI</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="OpenAI" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="OpenAI" />
   </ItemGroup>
 </Project>

--- a/src/llm/providers/WhisperDesk.Llm.Provider.AzureOpenAI/WhisperDesk.Llm.Provider.AzureOpenAI.csproj
+++ b/src/llm/providers/WhisperDesk.Llm.Provider.AzureOpenAI/WhisperDesk.Llm.Provider.AzureOpenAI.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
+    <ProjectReference Include="$(LlmRoot)WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/stt/WhisperDesk.Stt.Contract/WhisperDesk.Stt.Contract.csproj
+++ b/src/stt/WhisperDesk.Stt.Contract/WhisperDesk.Stt.Contract.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Stt.Contract</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/src/stt/WhisperDesk.Stt/WhisperDesk.Stt.csproj
+++ b/src/stt/WhisperDesk.Stt/WhisperDesk.Stt.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Stt</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
     <ProjectReference Include="..\providers\WhisperDesk.Stt.Provider.Azure\WhisperDesk.Stt.Provider.Azure.csproj" />
     <ProjectReference Include="..\providers\WhisperDesk.Stt.Provider.Volcengine\WhisperDesk.Stt.Provider.Volcengine.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/stt/WhisperDesk.Stt/WhisperDesk.Stt.csproj
+++ b/src/stt/WhisperDesk.Stt/WhisperDesk.Stt.csproj
@@ -4,9 +4,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
-    <ProjectReference Include="..\providers\WhisperDesk.Stt.Provider.Azure\WhisperDesk.Stt.Provider.Azure.csproj" />
-    <ProjectReference Include="..\providers\WhisperDesk.Stt.Provider.Volcengine\WhisperDesk.Stt.Provider.Volcengine.csproj" />
+    <ProjectReference Include="$(SttRoot)WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
+    <ProjectReference Include="$(SttRoot)providers\WhisperDesk.Stt.Provider.Azure\WhisperDesk.Stt.Provider.Azure.csproj" />
+    <ProjectReference Include="$(SttRoot)providers\WhisperDesk.Stt.Provider.Volcengine\WhisperDesk.Stt.Provider.Volcengine.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/stt/providers/WhisperDesk.Stt.Provider.Azure/WhisperDesk.Stt.Provider.Azure.csproj
+++ b/src/stt/providers/WhisperDesk.Stt.Provider.Azure/WhisperDesk.Stt.Provider.Azure.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
+    <ProjectReference Include="$(SttRoot)WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/stt/providers/WhisperDesk.Stt.Provider.Azure/WhisperDesk.Stt.Provider.Azure.csproj
+++ b/src/stt/providers/WhisperDesk.Stt.Provider.Azure/WhisperDesk.Stt.Provider.Azure.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Stt.Provider.Azure</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.42.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" />
   </ItemGroup>
 </Project>

--- a/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/WhisperDesk.Stt.Provider.Volcengine.csproj
+++ b/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/WhisperDesk.Stt.Provider.Volcengine.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
+    <ProjectReference Include="$(SttRoot)WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/WhisperDesk.Stt.Provider.Volcengine.csproj
+++ b/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/WhisperDesk.Stt.Provider.Volcengine.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>WhisperDesk.Stt.Provider.Volcengine</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 </Project>

--- a/tests/WhisperDesk.Tests/WhisperDesk.Tests.csproj
+++ b/tests/WhisperDesk.Tests/WhisperDesk.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\WhisperDesk\WhisperDesk.csproj" />
+    <ProjectReference Include="$(SrcRoot)WhisperDesk\WhisperDesk.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/WhisperDesk.Tests/WhisperDesk.Tests.csproj
+++ b/tests/WhisperDesk.Tests/WhisperDesk.Tests.csproj
@@ -2,18 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/weval-reader/WevalReader.csproj
+++ b/tools/weval-reader/WevalReader.csproj
@@ -1,10 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add `Directory.Packages.props` for central NuGet package version management
- Extract shared properties (`TargetFramework`, `Nullable`, `ImplicitUsings`) into `Directory.Build.props`
- Unify all `Microsoft.Extensions.*` packages to 9.0.0 (was mixed 8.0.x / 9.0.0)
- Upgrade `System.Text.Json` from 8.0.5 to 9.0.0
- Clean up all 11 csproj files — remove duplicated properties and inline version numbers

## Test plan
- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [ ] `dotnet test` passes
- [ ] `dotnet publish -c Release` produces working single-file exe