### PR TITLE
Treat warnings as errors across all projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Label="Module paths">


### PR DESCRIPTION
## Summary
- Add `TreatWarningsAsErrors` to `Directory.Build.props` to enforce zero warnings at build time for all projects

## Test plan
- [x] `dotnet build` succeeds with 0 warnings, 0 errors