### PR TITLE
Prevent multiple instances with Mutex

### DIFF
--- a/src/ui/WhisperDesk/App.xaml.cs
+++ b/src/ui/WhisperDesk/App.xaml.cs
@@ -25,10 +25,19 @@ public partial class App : Application
     private MainWindow? _mainWindow;
     private OverlayWindow? _overlayWindow;
     private WhisperDeskServer? _server;
+    private Mutex? _singleInstanceMutex;
 
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        _singleInstanceMutex = new Mutex(true, "WhisperDesk_SingleInstance", out var isNewInstance);
+        if (!isNewInstance)
+        {
+            MessageBox.Show("WhisperDesk is already running.", "WhisperDesk", MessageBoxButton.OK, MessageBoxImage.Information);
+            Shutdown();
+            return;
+        }
 
         try
         {
@@ -169,6 +178,8 @@ public partial class App : Application
         _mainWindow?.ForceClose();
 
         _server?.Dispose();
+        _singleInstanceMutex?.ReleaseMutex();
+        _singleInstanceMutex?.Dispose();
 
         if (_serviceProvider is IDisposable disposable)
         {


### PR DESCRIPTION
## Summary
- Added Mutex-based single instance check on startup
- Second instance shows "WhisperDesk is already running" and exits
- Mutex released on application exit

## Test plan
- [ ] First instance starts normally
- [ ] Second instance shows message box and exits
- [ ] After closing first instance, a new instance can start

🤖 Generated with [Claude Code](https://claude.com/claude-code)