### PR TITLE
Pass Claude Code dialog context to Volcengine STT

### DIFF
--- a/src/core/WhisperDesk.Core/Configuration/PipelineConfig.cs
+++ b/src/core/WhisperDesk.Core/Configuration/PipelineConfig.cs
@@ -30,6 +30,12 @@ public class PipelineConfig
     public AudioFormatConfig Audio { get; set; } = new();
 
     public double HistorySessionGapMinutes { get; set; } = 10;
+
+    /// <summary>Enable Claude Code dialog context for STT.</summary>
+    public bool EnableDialogContext { get; set; } = true;
+
+    /// <summary>Maximum number of recent dialog turns to include.</summary>
+    public int DialogContextMaxTurns { get; set; } = 3;
 }
 
 public class AudioFormatConfig

--- a/src/core/WhisperDesk.Core/Configuration/PipelineServiceRegistration.cs
+++ b/src/core/WhisperDesk.Core/Configuration/PipelineServiceRegistration.cs
@@ -26,6 +26,11 @@ public static class PipelineServiceRegistration
         // Context providers
         services.AddSingleton<IContextProvider, HotWordContextProvider>();
 
+        if (pipelineConfig.EnableDialogContext)
+        {
+            services.AddSingleton<IContextProvider, ClaudeDialogContextProvider>();
+        }
+
         // Post-processing stages
         if (pipelineConfig.EnableTextCleanup)
         {

--- a/src/core/WhisperDesk.Core/Pipeline/IContextProvider.cs
+++ b/src/core/WhisperDesk.Core/Pipeline/IContextProvider.cs
@@ -9,9 +9,12 @@ public interface IContextProvider
     /// <summary>Display name for logging/diagnostics.</summary>
     string Name { get; }
 
+    /// <summary>Execution order. Lower values run first.</summary>
+    int Order { get; }
+
     /// <summary>
     /// Contribute context to the session builder. Called once per session during startup.
-    /// Runs concurrently with other context providers.
+    /// Providers run sequentially in Order.
     /// </summary>
     Task ContributeAsync(SessionContextBuilder builder, CancellationToken ct = default);
 }

--- a/src/core/WhisperDesk.Core/Pipeline/SessionContextBuilder.cs
+++ b/src/core/WhisperDesk.Core/Pipeline/SessionContextBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using WhisperDesk.Stt.Contract;
 
 namespace WhisperDesk.Core.Pipeline;
 
@@ -11,6 +12,7 @@ public class SessionContextBuilder
     private readonly ConcurrentBag<string> _phraseHints = new();
     private readonly ConcurrentBag<string> _languages = new();
     private readonly ConcurrentDictionary<string, object> _metadata = new();
+    private readonly ConcurrentBag<(string Role, string Text)> _dialogTurns = new();
 
     /// <summary>Add phrase hints (hot words, technical terms) for improved recognition.</summary>
     public void AddPhraseHints(IEnumerable<string> hints)
@@ -41,4 +43,10 @@ public class SessionContextBuilder
 
     /// <summary>Snapshot the collected languages.</summary>
     public IReadOnlyList<string> Languages => _languages.ToArray();
+
+    /// <summary>Add a dialog turn (role + text) for dialog context.</summary>
+    public void AddDialogTurn(string role, string text) => _dialogTurns.Add((role, text));
+
+    /// <summary>Snapshot the collected dialog turns.</summary>
+    public IReadOnlyList<DialogTurn> DialogTurns => _dialogTurns.Select(t => new DialogTurn(t.Role, t.Text)).ToArray();
 }

--- a/src/core/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
+++ b/src/core/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
@@ -109,8 +109,10 @@ public class StreamingPipeline : IPipelineController, IDisposable
                 // 2. Prepare context + start STT in parallel
                 _contextBuilder = new SessionContextBuilder();
                 _contextBuilder.AddLanguages(_config.AutoDetectLanguages);
+                _contextBuilder.SetMetadata("foregroundProcess", _foregroundProcess);
+                _contextBuilder.SetMetadata("foregroundWindowTitle", _foregroundWindowTitle);
 
-                // Run context providers in parallel (non-blocking)
+                // Run context providers sequentially by Order (non-blocking)
                 await PrepareContextAsync(_contextBuilder, ct);
 
                 // 3. Build STT session options with collected context
@@ -118,7 +120,8 @@ public class StreamingPipeline : IPipelineController, IDisposable
                 {
                     AudioFormat = audioFormat,
                     Languages = _contextBuilder.Languages,
-                    PhraseHints = _contextBuilder.PhraseHints
+                    PhraseHints = _contextBuilder.PhraseHints,
+                    DialogContext = _contextBuilder.DialogTurns
                 };
 
                 // Wire partial results
@@ -263,20 +266,18 @@ public class StreamingPipeline : IPipelineController, IDisposable
 
     private async Task PrepareContextAsync(SessionContextBuilder builder, CancellationToken ct)
     {
-        var tasks = _contextProviders.Select(async provider =>
+        foreach (var provider in _contextProviders.OrderBy(p => p.Order))
         {
             try
             {
-                _logger.LogDebug("[Pipeline] Running context provider: {Name}", provider.Name);
+                _logger.LogDebug("[Pipeline] Running context provider: {Name} (order={Order})", provider.Name, provider.Order);
                 await provider.ContributeAsync(builder, ct);
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "[Pipeline] Context provider '{Name}' failed (non-fatal).", provider.Name);
             }
-        });
-
-        await Task.WhenAll(tasks);
+        }
     }
 
     private async Task<string> RunPostProcessingAsync(string text, CancellationToken ct)

--- a/src/core/WhisperDesk.Core/Stages/PreProcessing/ClaudeDialogContextProvider.cs
+++ b/src/core/WhisperDesk.Core/Stages/PreProcessing/ClaudeDialogContextProvider.cs
@@ -108,7 +108,7 @@ public class ClaudeDialogContextProvider : IContextProvider
         var turns = new List<(string Role, string Text)>();
 
         // Read from end to find the most recent turns first
-        for (int i = lines.Length - 1; i >= 0 && turns.Count < maxTurns * 2; i--)
+        for (int i = lines.Length - 1; i >= 0 && turns.Count < maxTurns; i--)
         {
             var line = lines[i];
             if (string.IsNullOrWhiteSpace(line)) continue;

--- a/src/core/WhisperDesk.Core/Stages/PreProcessing/ClaudeDialogContextProvider.cs
+++ b/src/core/WhisperDesk.Core/Stages/PreProcessing/ClaudeDialogContextProvider.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WhisperDesk.Core.Configuration;
+using WhisperDesk.Core.Pipeline;
+
+namespace WhisperDesk.Core.Stages.PreProcessing;
+
+/// <summary>
+/// Reads recent Claude Code conversation turns from the local JSONL files
+/// and contributes them as dialog context for STT recognition improvement.
+/// </summary>
+public class ClaudeDialogContextProvider : IContextProvider
+{
+    private readonly ILogger<ClaudeDialogContextProvider> _logger;
+    private readonly int _maxTurns;
+
+    public string Name => "Claude Dialog Context";
+    public int Order => 10;
+
+    public ClaudeDialogContextProvider(ILogger<ClaudeDialogContextProvider> logger, PipelineConfig config)
+    {
+        _logger = logger;
+        _maxTurns = config.DialogContextMaxTurns;
+        _logger.LogDebug("[ClaudeDialog] Initialized with maxTurns={MaxTurns}", _maxTurns);
+    }
+
+    public async Task ContributeAsync(SessionContextBuilder builder, CancellationToken ct = default)
+    {
+        // 1. Check foreground window to determine if user is in Claude Code
+        var process = builder.GetMetadata<string>("foregroundProcess") ?? "";
+        var title = builder.GetMetadata<string>("foregroundWindowTitle") ?? "";
+
+        _logger.LogDebug("[ClaudeDialog] Foreground: process={Process}, title={Title}", process, title);
+
+        if (!IsClaudeCode(process, title))
+        {
+            _logger.LogDebug("[ClaudeDialog] Not Claude Code window, skipping dialog context.");
+            return;
+        }
+
+        // 2. Locate Claude projects directory
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var projectsDir = Path.Combine(userProfile, ".claude", "projects");
+
+        if (!Directory.Exists(projectsDir))
+        {
+            _logger.LogDebug("[ClaudeDialog] Claude projects directory not found: {Dir}", projectsDir);
+            return;
+        }
+
+        // 3. Find the most recently modified JSONL conversation file
+        string[] jsonlFiles;
+        try
+        {
+            jsonlFiles = Directory.GetFiles(projectsDir, "*.jsonl", SearchOption.AllDirectories);
+            _logger.LogDebug("[ClaudeDialog] Found {Count} JSONL files in {Dir}", jsonlFiles.Length, projectsDir);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[ClaudeDialog] Failed to enumerate Claude project files in {Dir}", projectsDir);
+            return;
+        }
+
+        if (jsonlFiles.Length == 0)
+        {
+            _logger.LogDebug("[ClaudeDialog] No JSONL files found in {Dir}", projectsDir);
+            return;
+        }
+
+        var newestFile = jsonlFiles
+            .Select(f => (Path: f, LastWrite: File.GetLastWriteTimeUtc(f)))
+            .MaxBy(f => f.LastWrite)
+            .Path;
+
+        _logger.LogDebug("[ClaudeDialog] Using conversation file: {File}", newestFile);
+
+        // 4. Read and extract recent dialog turns
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(newestFile, ct);
+            _logger.LogDebug("[ClaudeDialog] Read {LineCount} lines from conversation file", lines.Length);
+
+            var turns = ExtractRecentTurns(lines, _maxTurns);
+
+            _logger.LogInformation("[ClaudeDialog] Loaded {Count} dialog turns from {File}",
+                turns.Count, Path.GetFileName(newestFile));
+
+            foreach (var (role, text) in turns)
+            {
+                _logger.LogDebug("[ClaudeDialog] Adding turn: role={Role}, textLength={Length}", role, text.Length);
+                builder.AddDialogTurn(role, text);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[ClaudeDialog] Failed to read conversation file: {File}", newestFile);
+        }
+    }
+
+    private static bool IsClaudeCode(string process, string title)
+    {
+        return process.Contains("claude", StringComparison.OrdinalIgnoreCase)
+            || title.Contains("claude", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private List<(string Role, string Text)> ExtractRecentTurns(string[] lines, int maxTurns)
+    {
+        var turns = new List<(string Role, string Text)>();
+
+        // Read from end to find the most recent turns first
+        for (int i = lines.Length - 1; i >= 0 && turns.Count < maxTurns * 2; i--)
+        {
+            var line = lines[i];
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+
+                // Only process user and assistant message types
+                if (!root.TryGetProperty("type", out var typeEl)) continue;
+                var type = typeEl.GetString();
+                if (type != "user" && type != "assistant") continue;
+
+                // Navigate to message.content array
+                if (!root.TryGetProperty("message", out var msg)) continue;
+                if (!msg.TryGetProperty("content", out var content)) continue;
+                if (content.ValueKind != JsonValueKind.Array) continue;
+
+                // Extract only text blocks (skip tool_use, tool_result, images, etc.)
+                var textParts = new List<string>();
+                foreach (var block in content.EnumerateArray())
+                {
+                    if (block.TryGetProperty("type", out var blockType)
+                        && blockType.GetString() == "text"
+                        && block.TryGetProperty("text", out var textEl))
+                    {
+                        var text = textEl.GetString();
+                        if (!string.IsNullOrWhiteSpace(text))
+                        {
+                            // Truncate long messages to stay within token budget
+                            textParts.Add(text.Length > 200 ? text[..200] + "..." : text);
+                        }
+                    }
+                }
+
+                if (textParts.Count > 0)
+                {
+                    turns.Add((type!, string.Join(" ", textParts)));
+                    _logger.LogDebug("[ClaudeDialog] Extracted {Role} turn at line {Line}, {Parts} text parts",
+                        type, i, textParts.Count);
+                }
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogDebug("[ClaudeDialog] Skipping malformed JSONL line at index {Index}: {Error}", i, ex.Message);
+            }
+        }
+
+        // Reverse so turns are in chronological order
+        turns.Reverse();
+        _logger.LogDebug("[ClaudeDialog] Extracted {Count} total turns from conversation", turns.Count);
+        return turns;
+    }
+}

--- a/src/core/WhisperDesk.Core/Stages/PreProcessing/HotWordContextProvider.cs
+++ b/src/core/WhisperDesk.Core/Stages/PreProcessing/HotWordContextProvider.cs
@@ -18,6 +18,7 @@ public class HotWordContextProvider : IContextProvider
     private DateTime _cachedLastWriteUtc;
 
     public string Name => "Hot Words";
+    public int Order => 20;
 
     public HotWordContextProvider(ILogger<HotWordContextProvider> logger, PipelineConfig config)
     {

--- a/src/stt/WhisperDesk.Stt.Contract/SttSessionOptions.cs
+++ b/src/stt/WhisperDesk.Stt.Contract/SttSessionOptions.cs
@@ -1,9 +1,12 @@
 namespace WhisperDesk.Stt.Contract;
 
+public record DialogTurn(string Role, string Text);
+
 public class SttSessionOptions
 {
     public IReadOnlyList<string> Languages { get; init; } = ["zh-CN", "en-US"];
     public IReadOnlyList<string> PhraseHints { get; init; } = [];
+    public IReadOnlyList<DialogTurn> DialogContext { get; init; } = [];
     public required AudioFormat AudioFormat { get; init; }
     public IReadOnlyDictionary<string, object> ProviderOptions { get; init; } = new Dictionary<string, object>();
 }

--- a/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/VolcengineSttProvider.cs
+++ b/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/VolcengineSttProvider.cs
@@ -278,15 +278,28 @@ public class VolcengineSttProvider : IStreamingSttProvider
 
     private static VolcengineCorpus? BuildCorpus(SttSessionOptions options)
     {
-        if (options.PhraseHints.Count == 0)
+        var hasHotwords = options.PhraseHints.Count > 0;
+        var hasDialogContext = options.DialogContext.Count > 0;
+
+        if (!hasHotwords && !hasDialogContext)
             return null;
 
-        var context = new VolcengineContext
+        var context = new VolcengineContext();
+
+        if (hasHotwords)
         {
-            Hotwords = options.PhraseHints
+            context.Hotwords = options.PhraseHints
                 .Select(w => new VolcengineHotword { Word = w })
-                .ToList()
-        };
+                .ToList();
+        }
+
+        if (hasDialogContext)
+        {
+            context.ContextType = "dialog_ctx";
+            context.ContextData = options.DialogContext
+                .Select(t => new VolcengineContextItem { Text = t.Text })
+                .ToList();
+        }
 
         var contextJson = JsonSerializer.Serialize(context, VolcengineJsonContext.Default.VolcengineContext);
         return new VolcengineCorpus { Context = contextJson };


### PR DESCRIPTION
## Summary
When the user's foreground window is Claude Code, the last 3 turns of conversation are passed to Volcengine STT as `dialog_ctx`. This helps the ASR model recognize technical terms being discussed.

## Changes
- **ClaudeDialogContextProvider** — reads Claude's JSONL conversation files, extracts recent user/assistant text
- **IContextProvider.Order** — providers now execute sequentially (was parallel)
- **SessionContextBuilder** — extended with `AddDialogTurn` / `DialogTurns`
- **Volcengine BuildCorpus** — sends hotwords + dialog context in same request
- **Config** — `EnableDialogContext` (bool), `DialogContextMaxTurns` (int)

## How it works
1. Pipeline starts → stores foreground process/title in builder metadata
2. ClaudeDialogContextProvider checks if foreground is Claude Code
3. If yes, finds newest JSONL in `~/.claude/projects/`, reads last 3 turns
4. Volcengine receives `corpus.context` with `context_type: "dialog_ctx"`

## Test plan
- [ ] `dotnet build` passes
- [ ] Focus Claude Code → speak → server.log shows "[ClaudeDialog] Loaded N turns"
- [ ] Focus other app → speak → server.log shows "[ClaudeDialog] Not Claude Code, skipping"
- [ ] Technical terms from conversation are recognized better

🤖 Generated with [Claude Code](https://claude.com/claude-code)