### PR TITLE
Add correction mode: undo and re-paste with RightAlt+Shift

### DIFF
--- a/src/core/WhisperDesk.Core.Contract/IPipelineController.cs
+++ b/src/core/WhisperDesk.Core.Contract/IPipelineController.cs
@@ -38,4 +38,10 @@ public interface IPipelineController : IDisposable
 
     /// <summary>Fired when a pipeline error occurs.</summary>
     event EventHandler<PipelineError> ErrorOccurred;
+
+    /// <summary>
+    /// Correct the last processed text using an LLM, given a spoken correction transcript.
+    /// Returns the corrected text, or null if no previous result exists.
+    /// </summary>
+    Task<string?> CorrectLastResultAsync(string correctionTranscript, CancellationToken ct = default);
 }

--- a/src/core/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
+++ b/src/core/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
@@ -3,7 +3,9 @@ using WhisperDesk.Core.Configuration;
 using WhisperDesk.Core.Contract;
 using WhisperDesk.Stt.Contract;
 using WhisperDesk.Core.Services;
+using WhisperDesk.Llm.Contract;
 using WhisperDesk.Transcript.Contract;
+using Fluid;
 
 namespace WhisperDesk.Core.Pipeline;
 
@@ -24,6 +26,10 @@ public class StreamingPipeline : IPipelineController, IDisposable
     private readonly IReadOnlyList<IPostProcessingStage> _postProcessingStages;
     private readonly AudioDeviceService _audioDeviceService;
     private readonly ITranscriptionHistoryService _historyService;
+    private readonly ILlmProvider _llmProvider;
+
+    private static readonly FluidParser _fluidParser = new();
+    private static readonly Lazy<IFluidTemplate> _correctionTemplate = new(LoadCorrectionTemplate);
 
     private PipelineState _state = PipelineState.Idle;
     private SessionContextBuilder? _contextBuilder;
@@ -59,6 +65,7 @@ public class StreamingPipeline : IPipelineController, IDisposable
         IStreamingSttProvider sttProvider,
         AudioDeviceService audioDeviceService,
         ITranscriptionHistoryService historyService,
+        ILlmProvider llmProvider,
         IEnumerable<IContextProvider> contextProviders,
         IEnumerable<IPostProcessingStage> postProcessingStages)
     {
@@ -68,6 +75,7 @@ public class StreamingPipeline : IPipelineController, IDisposable
         _sttProvider = sttProvider;
         _audioDeviceService = audioDeviceService;
         _historyService = historyService;
+        _llmProvider = llmProvider;
         _contextProviders = contextProviders;
         _postProcessingStages = postProcessingStages.OrderBy(s => s.Order).ToList();
     }
@@ -322,6 +330,62 @@ public class StreamingPipeline : IPipelineController, IDisposable
             Message = error.Message,
             Exception = error.Exception
         });
+    }
+
+    public async Task<string?> CorrectLastResultAsync(string correctionTranscript, CancellationToken ct = default)
+    {
+        _logger.LogInformation("[Pipeline] CorrectLastResultAsync called. CorrectionTranscript={CorrectionLen} chars, HasPrevious={HasPrev}",
+            correctionTranscript.Length, LastProcessedText != null);
+
+        if (string.IsNullOrEmpty(LastProcessedText))
+        {
+            _logger.LogWarning("[Pipeline] No previous processed text to correct.");
+            return null;
+        }
+
+        try
+        {
+            var template = _correctionTemplate.Value;
+            var templateContext = new TemplateContext();
+            templateContext.SetValue("previous_text", LastProcessedText);
+            templateContext.SetValue("correction_text", correctionTranscript);
+
+            var userPrompt = await template.RenderAsync(templateContext);
+            _logger.LogDebug("[Pipeline] Correction prompt rendered ({Length} chars).", userPrompt.Length);
+
+            var corrected = await _llmProvider.ProcessTextAsync(
+                "You are a transcription correction assistant. Apply the user's spoken correction to the previous transcription.",
+                userPrompt,
+                new LlmRequestOptions { Temperature = 0.2f },
+                ct);
+
+            _logger.LogInformation("[Pipeline] Correction complete. Previous={PrevLen} chars -> Corrected={CorrLen} chars.",
+                LastProcessedText.Length, corrected.Length);
+
+            LastProcessedText = corrected;
+            return corrected;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Pipeline] Correction failed.");
+            return null;
+        }
+    }
+
+    private static IFluidTemplate LoadCorrectionTemplate()
+    {
+        var assembly = typeof(StreamingPipeline).Assembly;
+        var resourceName = "WhisperDesk.Core.Stages.PostProcessing.Prompts.Correction.liquid";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        var templateText = reader.ReadToEnd();
+
+        if (!_fluidParser.TryParse(templateText, out var template, out var error))
+        {
+            throw new InvalidOperationException($"Failed to parse Correction.liquid: {error}");
+        }
+        return template;
     }
 
     public void Dispose()

--- a/src/core/WhisperDesk.Core/Stages/PostProcessing/Prompts/Correction.liquid
+++ b/src/core/WhisperDesk.Core/Stages/PostProcessing/Prompts/Correction.liquid
@@ -1,0 +1,9 @@
+The user's previous speech was transcribed and cleaned as:
+"{{ previous_text }}"
+
+The user then said a correction:
+"{{ correction_text }}"
+
+Apply the user's correction to the previous text. Replace the incorrect words/phrases with what the user intended. Keep everything else unchanged.
+
+Output ONLY the corrected full text. No explanation.

--- a/src/core/WhisperDesk.Core/WhisperDesk.Core.csproj
+++ b/src/core/WhisperDesk.Core/WhisperDesk.Core.csproj
@@ -4,6 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Stages\PostProcessing\Prompts\*.liquid" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(CoreRoot)WhisperDesk.Core.Contract\WhisperDesk.Core.Contract.csproj" />
     <ProjectReference Include="$(SttRoot)WhisperDesk.Stt.Contract\WhisperDesk.Stt.Contract.csproj" />
     <ProjectReference Include="$(LlmRoot)WhisperDesk.Llm.Contract\WhisperDesk.Llm.Contract.csproj" />
@@ -11,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Fluid.Core" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/proto/WhisperDesk.Proto/pipeline.proto
+++ b/src/proto/WhisperDesk.Proto/pipeline.proto
@@ -11,6 +11,7 @@ service PipelineService {
   rpc GetState(GetStateRequest) returns (GetStateResponse);
   rpc GetRecordingWav(GetRecordingWavRequest) returns (GetRecordingWavResponse);
   rpc Subscribe(SubscribeRequest) returns (stream PipelineEvent);
+  rpc CorrectLastResult(CorrectRequest) returns (CorrectResponse);
 }
 
 // Requests
@@ -23,6 +24,14 @@ message AbortSessionRequest {}
 message GetStateRequest {}
 message GetRecordingWavRequest {}
 message SubscribeRequest {}
+
+// Correction
+message CorrectRequest {
+  string correction_transcript = 1;
+}
+message CorrectResponse {
+  string corrected_text = 1;
+}
 
 // Responses
 message StartSessionResponse {}

--- a/src/server/WhisperDesk.Server/GrpcPipelineClient.cs
+++ b/src/server/WhisperDesk.Server/GrpcPipelineClient.cs
@@ -54,6 +54,17 @@ public class GrpcPipelineClient : IPipelineController, IDisposable
         await _client.AbortSessionAsync(new AbortSessionRequest());
     }
 
+    public async Task<string?> CorrectLastResultAsync(string correctionTranscript, CancellationToken ct = default)
+    {
+        var response = await _client.CorrectLastResultAsync(
+            new CorrectRequest { CorrectionTranscript = correctionTranscript },
+            cancellationToken: ct);
+        var text = response.CorrectedText;
+        if (!string.IsNullOrEmpty(text))
+            LastProcessedText = text;
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
     public byte[]? GetRecordingAsWav()
     {
         var response = _client.GetRecordingWav(new GetRecordingWavRequest());

--- a/src/server/WhisperDesk.Server/PipelineGrpcService.cs
+++ b/src/server/WhisperDesk.Server/PipelineGrpcService.cs
@@ -39,6 +39,12 @@ public class PipelineGrpcService : PipelineService.PipelineServiceBase
         return new AbortSessionResponse();
     }
 
+    public override async Task<CorrectResponse> CorrectLastResult(CorrectRequest request, ServerCallContext context)
+    {
+        var corrected = await _pipeline.CorrectLastResultAsync(request.CorrectionTranscript, context.CancellationToken);
+        return new CorrectResponse { CorrectedText = corrected ?? "" };
+    }
+
     public override Task<GetStateResponse> GetState(GetStateRequest request, ServerCallContext context)
     {
         var response = new GetStateResponse

--- a/src/ui/WhisperDesk/Models/WhisperDeskSettings.cs
+++ b/src/ui/WhisperDesk/Models/WhisperDeskSettings.cs
@@ -30,6 +30,7 @@ public class HotkeySettings
 {
     public string PushToTalk { get; set; } = "F9";
     public string PasteTranscription { get; set; } = "Ctrl+Shift+V";
+    public string CorrectionHotkey { get; set; } = "RightAlt+Shift";
 }
 
 public class AudioSettings

--- a/src/ui/WhisperDesk/Services/ClipboardPasteService.cs
+++ b/src/ui/WhisperDesk/Services/ClipboardPasteService.cs
@@ -34,4 +34,27 @@ public class ClipboardPasteService
             _logger.LogError(ex, "[PasteService] Failed to paste to active window");
         }
     }
+
+    /// <summary>
+    /// Undo the previous paste (Ctrl+Z) then paste the corrected text (Ctrl+V).
+    /// </summary>
+    public async Task UndoAndPasteAsync()
+    {
+        try
+        {
+            _logger.LogDebug("[PasteService] Sending Ctrl+Z to undo previous paste");
+            await Task.Delay(100);
+            SendKeys.SendWait("^z");
+
+            _logger.LogDebug("[PasteService] Waiting before paste...");
+            await Task.Delay(200);
+
+            SendKeys.SendWait("^v");
+            _logger.LogDebug("[PasteService] Undo and paste completed");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[PasteService] Failed to undo and paste");
+        }
+    }
 }

--- a/src/ui/WhisperDesk/Services/HotkeyService.cs
+++ b/src/ui/WhisperDesk/Services/HotkeyService.cs
@@ -12,11 +12,14 @@ public class HotkeyService : IDisposable
     private LowLevelKeyboardHook? _keyboardHook;
 
     private bool _pushToTalkActive;
+    private bool _correctionActive;
     private readonly HashSet<HKey> _pressedKeys = new();
 
     public event EventHandler? PushToTalkPressed;
     public event EventHandler? PushToTalkReleased;
     public event EventHandler? PasteHotkeyPressed;
+    public event EventHandler? CorrectionPressed;
+    public event EventHandler? CorrectionReleased;
 
     public HotkeyService(ILogger<HotkeyService> logger, HotkeySettings settings)
     {
@@ -40,8 +43,8 @@ public class HotkeyService : IDisposable
         _keyboardHook.Up += OnKeyUp;
         _keyboardHook.Start();
 
-        _logger.LogInformation("Hotkey service started. Push-to-talk: {PTT}, Paste: {Paste}",
-            _settings.PushToTalk, _settings.PasteTranscription);
+        _logger.LogInformation("Hotkey service started. Push-to-talk: {PTT}, Paste: {Paste}, Correction: {Correction}",
+            _settings.PushToTalk, _settings.PasteTranscription, _settings.CorrectionHotkey);
     }
 
     private void OnKeyDown(object? sender, KeyboardEventArgs e)
@@ -52,7 +55,7 @@ public class HotkeyService : IDisposable
         }
 
         // Check push-to-talk
-        if (!_pushToTalkActive && IsHotkeyPressed(_settings.PushToTalk))
+        if (!_pushToTalkActive && !_correctionActive && IsHotkeyPressed(_settings.PushToTalk))
         {
             _pushToTalkActive = true;
             e.IsHandled = true;
@@ -63,6 +66,23 @@ public class HotkeyService : IDisposable
 
         // While push-to-talk is held, swallow repeat events for the PTT key
         if (_pushToTalkActive && ContainsPushToTalkKey(e))
+        {
+            e.IsHandled = true;
+            return;
+        }
+
+        // Check correction hotkey
+        if (!_correctionActive && !_pushToTalkActive && IsHotkeyPressed(_settings.CorrectionHotkey))
+        {
+            _correctionActive = true;
+            e.IsHandled = true;
+            _logger.LogDebug("Correction hotkey activated");
+            CorrectionPressed?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        // While correction is held, swallow repeat events
+        if (_correctionActive && ContainsHotkeyKey(e, _settings.CorrectionHotkey))
         {
             e.IsHandled = true;
             return;
@@ -80,6 +100,7 @@ public class HotkeyService : IDisposable
     private void OnKeyUp(object? sender, KeyboardEventArgs e)
     {
         bool containsPttKey = ContainsPushToTalkKey(e);
+        bool containsCorrectionKey = ContainsHotkeyKey(e, _settings.CorrectionHotkey);
 
         foreach (var key in e.Keys.Values)
         {
@@ -101,14 +122,35 @@ public class HotkeyService : IDisposable
         {
             e.IsHandled = true;
         }
+
+        // Check if correction hotkey was released
+        if (_correctionActive && !IsHotkeyPressed(_settings.CorrectionHotkey))
+        {
+            _correctionActive = false;
+            e.IsHandled = true;
+            _logger.LogDebug("Correction hotkey released");
+            CorrectionReleased?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        // Swallow any correction-related key release while correction is still active
+        if (_correctionActive && containsCorrectionKey)
+        {
+            e.IsHandled = true;
+        }
     }
 
     /// <summary>
     /// Check if the keyboard event contains any key that is part of the push-to-talk hotkey.
     /// </summary>
-    private bool ContainsPushToTalkKey(KeyboardEventArgs e)
+    private bool ContainsPushToTalkKey(KeyboardEventArgs e) => ContainsHotkeyKey(e, _settings.PushToTalk);
+
+    /// <summary>
+    /// Check if the keyboard event contains any key that is part of the specified hotkey string.
+    /// </summary>
+    private bool ContainsHotkeyKey(KeyboardEventArgs e, string hotkeyString)
     {
-        var pttParts = _settings.PushToTalk.Split('+').Select(p => p.Trim().ToLowerInvariant());
+        var pttParts = hotkeyString.Split('+').Select(p => p.Trim().ToLowerInvariant());
         foreach (var part in pttParts)
         {
             HKey? targetKey = part switch

--- a/src/ui/WhisperDesk/ViewModels/MainViewModel.cs
+++ b/src/ui/WhisperDesk/ViewModels/MainViewModel.cs
@@ -24,6 +24,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly WhisperDeskSettings _appSettings;
     private CancellationTokenSource? _cts;
     private bool _isStopping;
+    private bool _isCorrectionMode;
 
     [ObservableProperty]
     private AppStatus _status = AppStatus.Idle;
@@ -54,6 +55,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     public string PushToTalkHint => $"\U0001f3a4 Hold {_appSettings.Hotkeys.PushToTalk} to record";
     public string PasteHint => $"\U0001f4cb Press {_appSettings.Hotkeys.PasteTranscription} to paste";
+    public string CorrectionHint => $"✏️ Hold {_appSettings.Hotkeys.CorrectionHotkey} to correct";
 
     public MainViewModel(
         ILogger<MainViewModel> logger,
@@ -80,6 +82,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _hotkeyService.PushToTalkPressed += OnPushToTalkPressed;
         _hotkeyService.PushToTalkReleased += OnPushToTalkReleased;
         _hotkeyService.PasteHotkeyPressed += OnPasteHotkeyPressed;
+        _hotkeyService.CorrectionPressed += OnCorrectionPressed;
+        _hotkeyService.CorrectionReleased += OnCorrectionReleased;
 
         _hotkeyService.Start();
     }
@@ -104,9 +108,87 @@ public partial class MainViewModel : ObservableObject, IDisposable
             CleanedText = result.ProcessedText;
             PartialText = string.Empty;
 
-            // Write to clipboard and paste — run off UI thread to avoid blocking animations
-            if (!string.IsNullOrEmpty(result.ProcessedText))
+            if (string.IsNullOrEmpty(result.ProcessedText))
+                return;
+
+            if (_isCorrectionMode)
             {
+                _logger.LogInformation("[ViewModel] Correction mode: sending correction transcript to LLM. Transcript={Len} chars",
+                    result.ProcessedText.Length);
+                _isCorrectionMode = false;
+                var correctionTranscript = result.ProcessedText;
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        _logger.LogDebug("[ViewModel] Calling CorrectLastResultAsync...");
+                        var corrected = await _pipeline.CorrectLastResultAsync(correctionTranscript);
+
+                        if (string.IsNullOrEmpty(corrected))
+                        {
+                            _logger.LogWarning("[ViewModel] Correction returned null/empty. No action taken.");
+                            return;
+                        }
+
+                        _logger.LogInformation("[ViewModel] Correction result: {Len} chars", corrected.Length);
+
+                        // Update UI
+                        Application.Current?.Dispatcher.InvokeAsync(() =>
+                        {
+                            CleanedText = corrected;
+                        });
+
+                        // Write corrected text to clipboard
+                        bool clipboardOk = false;
+                        var staThread = new Thread(() =>
+                        {
+                            for (int i = 0; i < 5; i++)
+                            {
+                                try
+                                {
+                                    Clipboard.SetDataObject(corrected, true);
+                                    clipboardOk = true;
+                                    _logger.LogInformation("[ViewModel] Corrected text copied to clipboard.");
+                                    break;
+                                }
+                                catch (System.Runtime.InteropServices.COMException ex)
+                                {
+                                    _logger.LogWarning("[ViewModel] Clipboard busy (attempt {Attempt}/5): {Message}", i + 1, ex.Message);
+                                    if (i < 4) Thread.Sleep(100);
+                                }
+                            }
+                        })
+                        {
+                            IsBackground = true
+                        };
+                        staThread.SetApartmentState(ApartmentState.STA);
+                        staThread.Start();
+                        staThread.Join();
+
+                        if (clipboardOk)
+                        {
+                            await Task.Delay(500);
+                            Application.Current?.Dispatcher.InvokeAsync(async () =>
+                            {
+                                _logger.LogDebug("[ViewModel] Performing undo + paste for correction.");
+                                await _pasteService.UndoAndPasteAsync();
+                            });
+                        }
+                        else
+                        {
+                            _logger.LogWarning("[ViewModel] Clipboard unavailable after retries, skipping correction paste.");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "[ViewModel] Correction mode failed.");
+                    }
+                });
+            }
+            else
+            {
+                // Normal mode: write to clipboard and paste
                 var textToPaste = result.ProcessedText;
                 _ = Task.Run(async () =>
                 {
@@ -192,6 +274,51 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             if (Status == AppStatus.Listening && !_isStopping)
             {
+                _isStopping = true;
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await _pipeline.StopSessionAsync(_cts?.Token ?? CancellationToken.None);
+                    }
+                    finally
+                    {
+                        Application.Current?.Dispatcher.InvokeAsync(() => _isStopping = false);
+                    }
+                });
+            }
+        });
+    }
+
+    private void OnCorrectionPressed(object? sender, EventArgs e)
+    {
+        Application.Current?.Dispatcher.InvokeAsync(() =>
+        {
+            if (Status == AppStatus.Idle || Status == AppStatus.Ready || Status == AppStatus.Error)
+            {
+                if (string.IsNullOrEmpty(_pipeline.LastProcessedText))
+                {
+                    _logger.LogWarning("[ViewModel] Correction hotkey pressed but no previous result to correct.");
+                    return;
+                }
+
+                _logger.LogInformation("[ViewModel] Correction mode activated. Previous text: {Len} chars", _pipeline.LastProcessedText.Length);
+                _isCorrectionMode = true;
+                PartialText = string.Empty;
+                var (proc, title) = ForegroundWindowInfo.Get();
+                _cts = new CancellationTokenSource();
+                _ = Task.Run(() => _pipeline.StartSessionAsync(proc, title, _cts.Token));
+            }
+        });
+    }
+
+    private void OnCorrectionReleased(object? sender, EventArgs e)
+    {
+        Application.Current?.Dispatcher.InvokeAsync(() =>
+        {
+            if (Status == AppStatus.Listening && !_isStopping)
+            {
+                _logger.LogDebug("[ViewModel] Correction hotkey released, stopping session.");
                 _isStopping = true;
                 _ = Task.Run(async () =>
                 {
@@ -360,6 +487,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _hotkeyService.PushToTalkPressed -= OnPushToTalkPressed;
         _hotkeyService.PushToTalkReleased -= OnPushToTalkReleased;
         _hotkeyService.PasteHotkeyPressed -= OnPasteHotkeyPressed;
+        _hotkeyService.CorrectionPressed -= OnCorrectionPressed;
+        _hotkeyService.CorrectionReleased -= OnCorrectionReleased;
 
         _cts?.Cancel();
         _cts?.Dispose();

--- a/src/ui/WhisperDesk/Views/MainWindow.xaml
+++ b/src/ui/WhisperDesk/Views/MainWindow.xaml
@@ -221,6 +221,8 @@
                                    Style="{StaticResource MaterialDesignCaptionTextBlock}" Opacity="0.6" />
                         <TextBlock Text="{Binding PasteHint}"
                                    Style="{StaticResource MaterialDesignCaptionTextBlock}" Opacity="0.6" />
+                        <TextBlock Text="{Binding CorrectionHint}"
+                                   Style="{StaticResource MaterialDesignCaptionTextBlock}" Opacity="0.6" />
                     </StackPanel>
 
                     <!-- Record button -->

--- a/src/ui/WhisperDesk/appsettings.json
+++ b/src/ui/WhisperDesk/appsettings.json
@@ -16,7 +16,8 @@
   },
   "Hotkeys": {
     "PushToTalk": "RightAlt",
-    "PasteTranscription": "Ctrl+Shift+V"
+    "PasteTranscription": "Ctrl+Shift+V",
+    "CorrectionHotkey": "RightAlt+Shift"
   },
   "Audio": {
     "SampleRate": 16000,


### PR DESCRIPTION
## Summary
Hold **RightAlt+Shift** to speak a correction (e.g. "不是STD，是STT"). The system:
1. Records and transcribes the correction as normal
2. Sends previous result + correction to LLM → produces corrected full text
3. Ctrl+Z undoes the previous paste
4. Pastes the corrected text

## Changes
- **HotkeyService** — CorrectionPressed/Released events, configurable hotkey
- **Proto** — new CorrectLastResult RPC
- **StreamingPipeline** — CorrectLastResultAsync with Liquid prompt template
- **ClipboardPasteService** — UndoAndPasteAsync (Ctrl+Z → Ctrl+V)
- **MainViewModel** — correction mode flag, routes to undo+re-paste flow

## Config
```json
"Hotkeys": {
  "CorrectionHotkey": "RightAlt+Shift"
}
```

## Test plan
- [ ] `dotnet build` passes
- [ ] Normal PTT works as before
- [ ] RightAlt+Shift records, transcribes, corrects previous text
- [ ] Ctrl+Z undoes previous paste, corrected text is pasted

🤖 Generated with [Claude Code](https://claude.com/claude-code)