### PR TITLE
feat: auto-inject Transcribe-mode transcript via SendInput Unicode

### DIFF
--- a/src/core/WhisperDesk.Core.Contract/PipelineResult.cs
+++ b/src/core/WhisperDesk.Core.Contract/PipelineResult.cs
@@ -15,4 +15,6 @@ public record PipelineResult
     public string Language { get; init; } = "zh";
 
     public string? SourceFile { get; init; }
+
+    public SessionMode Mode { get; init; } = SessionMode.Transcribe;
 }

--- a/src/core/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
+++ b/src/core/WhisperDesk.Core/Pipeline/StreamingPipeline.cs
@@ -219,7 +219,8 @@ public class StreamingPipeline : IPipelineController, IDisposable
             {
                 RawTranscript = rawTranscript,
                 ProcessedText = processedText,
-                Language = _config.Language
+                Language = _config.Language,
+                Mode = _sessionMode
             };
 
             State = PipelineState.Completed;

--- a/src/proto/WhisperDesk.Proto/pipeline.proto
+++ b/src/proto/WhisperDesk.Proto/pipeline.proto
@@ -77,6 +77,7 @@ message PipelineResultDto {
   int64 timestamp_ticks = 4;
   string language = 5;
   optional string source_file = 6;
+  SessionModeDto mode = 7;
 }
 
 message PipelineErrorDto {

--- a/src/server/WhisperDesk.Server/GrpcPipelineClient.cs
+++ b/src/server/WhisperDesk.Server/GrpcPipelineClient.cs
@@ -178,13 +178,20 @@ public class GrpcPipelineClient : IPipelineController, IDisposable
         ProcessedText = dto.ProcessedText,
         AudioDuration = TimeSpan.FromTicks(dto.AudioDurationTicks),
         Timestamp = new DateTime(dto.TimestampTicks),
-        Language = dto.Language
+        Language = dto.Language,
+        Mode = MapMode(dto.Mode)
     };
 
     private static SessionModeDto MapMode(SessionMode mode) => mode switch
     {
         SessionMode.Instruct => SessionModeDto.Instruct,
         _ => SessionModeDto.Transcribe
+    };
+
+    private static SessionMode MapMode(SessionModeDto mode) => mode switch
+    {
+        SessionModeDto.Instruct => SessionMode.Instruct,
+        _ => SessionMode.Transcribe
     };
 
     public void Dispose()

--- a/src/server/WhisperDesk.Server/PipelineGrpcService.cs
+++ b/src/server/WhisperDesk.Server/PipelineGrpcService.cs
@@ -151,12 +151,19 @@ public class PipelineGrpcService : PipelineService.PipelineServiceBase
         _ => SessionMode.Transcribe
     };
 
+    private static SessionModeDto MapMode(SessionMode mode) => mode switch
+    {
+        SessionMode.Instruct => SessionModeDto.Instruct,
+        _ => SessionModeDto.Transcribe
+    };
+
     private static PipelineResultDto MapResult(PipelineResult result) => new()
     {
         RawTranscript = result.RawTranscript,
         ProcessedText = result.ProcessedText,
         AudioDurationTicks = result.AudioDuration.Ticks,
         TimestampTicks = result.Timestamp.Ticks,
-        Language = result.Language ?? ""
+        Language = result.Language ?? "",
+        Mode = MapMode(result.Mode)
     };
 }

--- a/src/ui/WhisperDesk/App.xaml.cs
+++ b/src/ui/WhisperDesk/App.xaml.cs
@@ -147,6 +147,7 @@ public partial class App : Application
         services.AddSingleton<IPipelineController>(grpcClient);
         services.AddSingleton(new GrpcDeviceClient(serverAddress));
         services.AddSingleton<HotkeyService>();
+        services.AddSingleton<TextInjectionService>();
         services.AddSingleton<MainViewModel>();
         services.AddSingleton<MainWindow>();
     }

--- a/src/ui/WhisperDesk/Services/TextInjectionService.cs
+++ b/src/ui/WhisperDesk/Services/TextInjectionService.cs
@@ -1,0 +1,122 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace WhisperDesk.Services;
+
+/// <summary>
+/// Injects text into whatever window currently has keyboard focus by synthesizing
+/// Unicode keyboard input via Win32 <c>SendInput</c> with <c>KEYEVENTF_UNICODE</c>.
+/// Avoids the clipboard entirely. Works across virtually any focusable surface
+/// (Notepad, terminals, browsers, Electron apps, Office, IDEs).
+/// </summary>
+public sealed partial class TextInjectionService
+{
+    private const ushort INPUT_KEYBOARD = 1;
+    private const uint KEYEVENTF_KEYUP = 0x0002;
+    private const uint KEYEVENTF_UNICODE = 0x0004;
+
+    private readonly ILogger<TextInjectionService> _logger;
+
+    public TextInjectionService(ILogger<TextInjectionService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Synchronously injects <paramref name="text"/> as a stream of Unicode keystrokes
+    /// into the currently focused window. Safe to call from any thread.
+    /// </summary>
+    public void InjectText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        // Two INPUT events per UTF-16 code unit: down then up.
+        // Surrogate pairs occupy two code units; Windows reassembles them.
+        var inputs = new INPUT[text.Length * 2];
+        for (int i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            inputs[i * 2] = NewKeyInput(ch, isKeyUp: false);
+            inputs[i * 2 + 1] = NewKeyInput(ch, isKeyUp: true);
+        }
+
+        var sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+        if (sent != inputs.Length)
+        {
+            var err = Marshal.GetLastWin32Error();
+            _logger.LogWarning("[TextInjection] SendInput sent {Sent}/{Expected}, lastError={Err}",
+                sent, inputs.Length, err);
+        }
+        else
+        {
+            _logger.LogInformation("[TextInjection] Injected {Chars} chars.", text.Length);
+        }
+    }
+
+    private static INPUT NewKeyInput(char ch, bool isKeyUp) => new()
+    {
+        type = INPUT_KEYBOARD,
+        U = new InputUnion
+        {
+            ki = new KEYBDINPUT
+            {
+                wVk = 0,
+                wScan = ch,
+                dwFlags = KEYEVENTF_UNICODE | (isKeyUp ? KEYEVENTF_KEYUP : 0),
+                time = 0,
+                dwExtraInfo = IntPtr.Zero
+            }
+        }
+    };
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    private static partial uint SendInput(uint cInputs, [In] INPUT[] pInputs, int cbSize);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT
+    {
+        public uint type;
+        public InputUnion U;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion
+    {
+        [FieldOffset(0)] public KEYBDINPUT ki;
+        // Size padding so the union matches the largest variant (MOUSEINPUT on x64 is the biggest).
+        [FieldOffset(0)] private MOUSEINPUT _mi;
+        [FieldOffset(0)] private HARDWAREINPUT _hi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MOUSEINPUT
+    {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HARDWAREINPUT
+    {
+        public uint uMsg;
+        public ushort wParamL;
+        public ushort wParamH;
+    }
+}

--- a/src/ui/WhisperDesk/ViewModels/MainViewModel.cs
+++ b/src/ui/WhisperDesk/ViewModels/MainViewModel.cs
@@ -21,6 +21,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly HotkeyService _hotkeyService;
     private readonly GrpcDeviceClient _deviceClient;
     private readonly WhisperDeskSettings _appSettings;
+    private readonly TextInjectionService _textInjection;
     private CancellationTokenSource? _cts;
     private bool _isStopping;
     private WindowTextContext? _sessionTextContext;
@@ -59,13 +60,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         IPipelineController pipeline,
         HotkeyService hotkeyService,
         GrpcDeviceClient deviceClient,
-        WhisperDeskSettings appSettings)
+        WhisperDeskSettings appSettings,
+        TextInjectionService textInjection)
     {
         _logger = logger;
         _pipeline = pipeline;
         _hotkeyService = hotkeyService;
         _deviceClient = deviceClient;
         _appSettings = appSettings;
+        _textInjection = textInjection;
 
         // Wire pipeline events
         _pipeline.StateChanged += OnPipelineStateChanged;
@@ -131,34 +134,24 @@ public partial class MainViewModel : ObservableObject, IDisposable
             CleanedText = result.ProcessedText;
             PartialText = string.Empty;
 
-            _logger.LogInformation("[ViewModel] Session completed. Raw: {RawLen} chars, Cleaned: {CleanLen} chars.",
-                RawText.Length, CleanedText.Length);
-            // if (!string.IsNullOrEmpty(result.ProcessedText))
-            // {
-            //     var textToPaste = result.ProcessedText;
-            //     var capturedContext = _sessionTextContext;
-            //     if (capturedContext is { } ctx)
-            //     {
-            //         var staThread = new Thread(() =>
-            //         {
-            //             var replaceResult = ForegroundWindowInfo.Append(ctx,  textToPaste);
-            //             if (replaceResult == ForegroundWindowInfo.Success)
-            //                 _logger.LogInformation("[ViewModel] Text inserted via Append.");
-            //             else
-            //                 _logger.LogWarning("[ViewModel] Append failed: {Reason}. Selected='{Selected}', Window={Handle}",
-            //                     replaceResult, ctx.Selected, ctx.WindowHandle);
-            //         });
-            //         staThread.SetApartmentState(ApartmentState.STA);
-            //         staThread.IsBackground = true;
-            //         staThread.Start();
-            //     }
-            //     else
-            //     {
-            //         _logger.LogWarning("[ViewModel] No session context captured, text not inserted.");
-            //     }
-                
-            // }
+            _logger.LogInformation("[ViewModel] Session completed (mode={Mode}). Raw: {RawLen} chars, Cleaned: {CleanLen} chars.",
+                result.Mode, RawText.Length, CleanedText.Length);
         });
+
+        if (result.Mode == SessionMode.Transcribe && !string.IsNullOrEmpty(result.ProcessedText))
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    _textInjection.InjectText(result.ProcessedText);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "[ViewModel] Text injection failed.");
+                }
+            });
+        }
     }
 
     private void OnPipelineError(object? sender, PipelineError error)


### PR DESCRIPTION
## Summary
After PR #35 removed the paste hotkey and `ClipboardPasteService`, Transcribe mode (`RightAlt`) had no way to deliver the cleaned transcript to the focused window — it only appeared in the main window. This PR closes that loop.

When a Transcribe session completes, the cleaned text is injected directly into whatever window currently has keyboard focus via Win32 `SendInput` with `KEYEVENTF_UNICODE`. Each UTF-16 code unit becomes a synthetic key down/up pair; Windows reassembles surrogate pairs for emoji and astral characters automatically. This:
- Does not touch the clipboard.
- Does not simulate `Ctrl+V`.
- Works in Notepad, terminals, browsers, Electron apps, Office, IDEs, etc.
- Needs no installation, no admin rights, no COM/IME registration.

## Changes
- **`PipelineResult.Mode`**: result now carries the `SessionMode` it ran under so the UI knows whether to inject.
- **proto `PipelineResultDto.mode`** + both gRPC mappings.
- **`StreamingPipeline`** fills `Mode = _sessionMode` on each result.
- **New `TextInjectionService`** wraps `SendInput` (`KEYEVENTF_UNICODE`) with a `LibraryImport` partial and an `INPUT/KEYBDINPUT` struct trio.
- **`MainViewModel.OnSessionCompleted`** dispatches `_textInjection.InjectText(...)` on a background `Task.Run` when `Mode == Transcribe && ProcessedText` is non-empty. The previously commented-out UIA `Append` block is deleted.

## Out of scope (next PR)
Instruct mode's `ForegroundWindowInfo.Append/Replace` path still uses `Clipboard.SetText` + `SendKeys.SendWait(\"^v\")`. Migrating Instruct to `SendInput` (and consolidating both modes onto one injection service) is a follow-up.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors.
- [x] `dotnet test` — 10/10 passing.
- [x] Manual: put a known string on the clipboard, hold `RightAlt`, say a Chinese sentence in Notepad/VS Code — text inserted at cursor, clipboard unchanged. (Confirmed by user.)
- [ ] Long text (>200 chars): single `SendInput` call covers it.
- [ ] Instruct mode (`RightAlt+Shift`) untouched — still goes through the existing Append/Replace LLM tool path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)