### PR TITLE
fix: stop listening overlay from resizing with waveform animation

### DIFF
--- a/src/ui/WhisperDesk/Views/OverlayWindow.xaml
+++ b/src/ui/WhisperDesk/Views/OverlayWindow.xaml
@@ -123,7 +123,8 @@
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
 
                 <!-- Waveform bars (Listening state) -->
-                <StackPanel x:Name="WaveformPanel" Orientation="Horizontal" VerticalAlignment="Center"
+                <!-- Fixed-height host so animating bar heights never resize the window -->
+                <StackPanel x:Name="WaveformPanel" Orientation="Horizontal" Height="28" VerticalAlignment="Center"
                             Visibility="Collapsed" Margin="0,0,10,0">
                     <Rectangle x:Name="WaveBar1" Width="3" Height="4" RadiusX="1.5" RadiusY="1.5"
                                Fill="#B388FF" Margin="1,0" VerticalAlignment="Center"/>


### PR DESCRIPTION
## Summary
- The listening overlay (`OverlayWindow.xaml`) uses `SizeToContent="WidthAndHeight"`. The five waveform bars continuously animate their `Height` (up to 26px), so each animation tick re-measured the layout and the capsule grew/shrank in a loop.
- Wrapped the waveform bars' `StackPanel` in a fixed `Height="28"` host so the bars animate inside a stable container without driving the window size.

## Test plan
- [x] `dotnet build` succeeds
- [x] Run the app, hold Right Alt to enter Listening state — capsule stays a fixed size while the bars bounce inside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)