### PR TITLE
fix: inject text via clipboard paste over Remote Desktop

### DIFF
--- a/src/ui/WhisperDesk/Services/TextInjectionService.cs
+++ b/src/ui/WhisperDesk/Services/TextInjectionService.cs
@@ -1,19 +1,39 @@
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace WhisperDesk.Services;
 
 /// <summary>
-/// Injects text into whatever window currently has keyboard focus by synthesizing
-/// Unicode keyboard input via Win32 <c>SendInput</c> with <c>KEYEVENTF_UNICODE</c>.
-/// Avoids the clipboard entirely. Works across virtually any focusable surface
-/// (Notepad, terminals, browsers, Electron apps, Office, IDEs).
+/// Injects text into whatever window currently has keyboard focus.
+/// <para>
+/// Default path synthesizes Unicode keyboard input via Win32 <c>SendInput</c> with
+/// <c>KEYEVENTF_UNICODE</c>. This avoids the clipboard and works across virtually any
+/// focusable surface (Notepad, terminals, browsers, Electron apps, Office, IDEs).
+/// </para>
+/// <para>
+/// Exception: when the focused window belongs to a Remote Desktop client (mstsc/msrdc),
+/// Unicode-only synthetic input carries no scan code and mstsc does not forward it into
+/// the remote session. There we fall back to clipboard redirection (which mstsc shares
+/// with the remote host by default) plus a scan-code Ctrl+V, restoring the prior
+/// clipboard afterwards.
+/// </para>
 /// </summary>
 public sealed partial class TextInjectionService
 {
     private const ushort INPUT_KEYBOARD = 1;
     private const uint KEYEVENTF_KEYUP = 0x0002;
     private const uint KEYEVENTF_UNICODE = 0x0004;
+    private const uint KEYEVENTF_SCANCODE = 0x0008;
+
+    // Hardware scan codes (set 1) for a scan-code Ctrl+V. Real scan codes are what
+    // mstsc forwards into the remote session; KEYEVENTF_UNICODE events are not.
+    private const ushort SCAN_ESC = 0x01;
+    private const ushort SCAN_LCTRL = 0x1D;
+    private const ushort SCAN_V = 0x2F;
+    private const int RemoteClipboardPropagationDelayMs = 200;
+    private const int RemoteMenuDismissDelayMs = 30;
+    private const int RemotePasteCompletionDelayMs = 200;
 
     private readonly ILogger<TextInjectionService> _logger;
 
@@ -23,13 +43,21 @@ public sealed partial class TextInjectionService
     }
 
     /// <summary>
-    /// Synchronously injects <paramref name="text"/> as a stream of Unicode keystrokes
-    /// into the currently focused window. Safe to call from any thread.
+    /// Synchronously injects <paramref name="text"/> into the currently focused window.
+    /// Uses Unicode <c>SendInput</c> normally; switches to clipboard paste when the
+    /// foreground window is a Remote Desktop client. Safe to call from any thread.
     /// </summary>
     public void InjectText(string text)
     {
         if (string.IsNullOrEmpty(text))
         {
+            return;
+        }
+
+        if (IsForegroundRemoteDesktop())
+        {
+            _logger.LogInformation("[TextInjection] Remote Desktop foreground detected; using clipboard paste.");
+            InjectViaClipboardPaste(text);
             return;
         }
 
@@ -55,6 +83,193 @@ public sealed partial class TextInjectionService
             _logger.LogInformation("[TextInjection] Injected {Chars} chars.", text.Length);
         }
     }
+
+    // Remote Desktop client process names. mstsc = classic Windows RDP client,
+    // msrdc = the newer "Remote Desktop" / Azure Virtual Desktop client.
+    private static readonly HashSet<string> RemoteDesktopProcesses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mstsc",
+        "msrdc",
+    };
+
+    private static bool IsForegroundRemoteDesktop()
+    {
+        var (processName, _) = ForegroundWindowInfo.Get();
+        return RemoteDesktopProcesses.Contains(processName);
+    }
+
+    /// <summary>
+    /// Places <paramref name="text"/> on the clipboard, sends a scan-code Ctrl+V, then
+    /// restores the previous clipboard. Used for Remote Desktop targets where Unicode
+    /// SendInput is dropped at the RDP boundary but clipboard redirection works.
+    /// </summary>
+    private void InjectViaClipboardPaste(string text)
+    {
+        if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA)
+        {
+            InjectViaClipboardPasteCore(text);
+            return;
+        }
+
+        Exception? threadException = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                InjectViaClipboardPasteCore(text);
+            }
+            catch (Exception ex)
+            {
+                threadException = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "WhisperDeskRdpClipboardPaste"
+        };
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (threadException != null)
+        {
+            _logger.LogWarning(threadException, "[TextInjection] RDP clipboard paste STA worker failed.");
+        }
+    }
+
+    private void InjectViaClipboardPasteCore(string text)
+    {
+        string? previous = null;
+        try
+        {
+            if (System.Windows.Clipboard.ContainsText())
+            {
+                previous = System.Windows.Clipboard.GetText();
+            }
+
+            if (!TrySetClipboardText(text))
+            {
+                _logger.LogWarning("[TextInjection] Clipboard set failed; aborting RDP paste.");
+                return;
+            }
+
+            // Give RDP clipboard redirection a moment to propagate to the remote host
+            // before the remote session processes the paste.
+            Thread.Sleep(RemoteClipboardPropagationDelayMs);
+            SendScanCodeKey(SCAN_ESC, "Esc");
+            Thread.Sleep(RemoteMenuDismissDelayMs);
+            SendScanCodePaste();
+            Thread.Sleep(RemotePasteCompletionDelayMs);
+            _logger.LogInformation("[TextInjection] Pasted {Chars} chars via clipboard (RDP).", text.Length);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[TextInjection] RDP clipboard paste failed.");
+        }
+        finally
+        {
+            RestoreClipboard(previous);
+        }
+    }
+
+    private void SendScanCodeKey(ushort scanCode, string keyName)
+    {
+        var inputs = new[]
+        {
+            NewScanInput(scanCode, isKeyUp: false),
+            NewScanInput(scanCode, isKeyUp: true),
+        };
+
+        var sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+        if (sent != inputs.Length)
+        {
+            var err = Marshal.GetLastWin32Error();
+            _logger.LogWarning("[TextInjection] {Key} SendInput sent {Sent}/{Expected}, lastError={Err}",
+                keyName, sent, inputs.Length, err);
+        }
+    }
+
+    private void SendScanCodePaste()
+    {
+        var inputs = new[]
+        {
+            NewScanInput(SCAN_LCTRL, isKeyUp: false),
+            NewScanInput(SCAN_V, isKeyUp: false),
+            NewScanInput(SCAN_V, isKeyUp: true),
+            NewScanInput(SCAN_LCTRL, isKeyUp: true),
+        };
+
+        var sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+        if (sent != inputs.Length)
+        {
+            var err = Marshal.GetLastWin32Error();
+            _logger.LogWarning("[TextInjection] Ctrl+V SendInput sent {Sent}/{Expected}, lastError={Err}",
+                sent, inputs.Length, err);
+        }
+    }
+
+    // Clipboard SetText is flaky under contention; retry until it reflects what we set.
+    private const int ClipboardRetryAttempts = 8;
+    private const int ClipboardRetryDelayMs = 25;
+
+    private bool TrySetClipboardText(string text)
+    {
+        for (var i = 0; i < ClipboardRetryAttempts; i++)
+        {
+            try
+            {
+                System.Windows.Clipboard.SetText(text);
+                if (System.Windows.Clipboard.ContainsText() &&
+                    System.Windows.Clipboard.GetText() == text)
+                {
+                    return true;
+                }
+            }
+            catch (Exception ex) when (i < ClipboardRetryAttempts - 1)
+            {
+                _logger.LogDebug(ex, "[TextInjection] Clipboard SetText attempt {Attempt} failed; retrying.", i + 1);
+            }
+            Thread.Sleep(ClipboardRetryDelayMs);
+        }
+        _logger.LogWarning("[TextInjection] Clipboard SetText failed after {Attempts} attempts.", ClipboardRetryAttempts);
+        return false;
+    }
+
+    private void RestoreClipboard(string? previous)
+    {
+        try
+        {
+            if (previous != null)
+            {
+                TrySetClipboardText(previous);
+            }
+            else
+            {
+                System.Windows.Clipboard.Clear();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "[TextInjection] Clipboard restore failed.");
+        }
+    }
+
+    private static INPUT NewScanInput(ushort scanCode, bool isKeyUp) => new()
+    {
+        type = INPUT_KEYBOARD,
+        U = new InputUnion
+        {
+            ki = new KEYBDINPUT
+            {
+                wVk = 0,
+                wScan = scanCode,
+                dwFlags = KEYEVENTF_SCANCODE | (isKeyUp ? KEYEVENTF_KEYUP : 0),
+                time = 0,
+                dwExtraInfo = IntPtr.Zero
+            }
+        }
+    };
 
     private static INPUT NewKeyInput(char ch, bool isKeyUp) => new()
     {


### PR DESCRIPTION
## Summary
- 在远程桌面(mstsc/msrdc)会话里,语音转出的文字无法插入到 Devbox 光标处。根因:当前注入用 `SendInput` + `KEYEVENTF_UNICODE`,这种合成事件不带扫描码,Windows App / mstsc 不会把它转发进远程会话。
- 修复:检测到前台窗口是远程桌面客户端时,改走**剪贴板重定向 + scancode Ctrl+V**(RDP 默认共享剪贴板到远程),粘贴后恢复原剪贴板。非 RDP 场景保持原有 Unicode 注入不变。
- 剪贴板操作在 STA 工作线程上执行;粘贴前先发一次 Esc,关掉激活热键可能在远程触发的菜单。

## 实现要点
- `IsForegroundRemoteDesktop()` 复用 `ForegroundWindowInfo.Get()` 拿前台进程名,匹配 `mstsc`/`msrdc`。
- `InjectViaClipboardPaste` → STA 线程 → `InjectViaClipboardPasteCore`:备份剪贴板 → 置文本(带 8 次重试)→ Esc → scancode Ctrl+V → 恢复剪贴板。
- 仅改动 `TextInjectionService.cs`,非 RDP 路径行为不变。

## Test plan
- [x] `dotnet build` 编译通过(0 警告 0 错误)。
- [x] 远程桌面(Windows App)会话:按住激活键说中文 → 文字正确插入到 Devbox 光标处。
- [ ] 本机回归:非 RDP 窗口(记事本/VS Code)说中文 → 仍走 Unicode 注入,正常插入,剪贴板内容在注入后恢复。
- [ ] 确认 RDP 检测准确:焦点在远程桌面窗口走粘贴,焦点切回主机本地窗口走 Unicode 注入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)