### PR TITLE
Fix Volcengine audio drops

### DIFF
--- a/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/VolcengineSttProvider.cs
+++ b/src/stt/providers/WhisperDesk.Stt.Provider.Volcengine/VolcengineSttProvider.cs
@@ -35,6 +35,7 @@ public class VolcengineSttProvider : IStreamingSttProvider
     private CancellationTokenSource? _sessionCts;
 
     private ConcurrentQueue<string> _results = new();
+    private string _lastPartialText = string.Empty;
     private TaskCompletionSource<bool>? _sessionCompleteTcs;
 
     public string Name => "Volcengine Doubao";
@@ -54,11 +55,11 @@ public class VolcengineSttProvider : IStreamingSttProvider
         _logger.LogInformation("[Volcengine] Starting session...");
 
         _results = new ConcurrentQueue<string>();
+        _lastPartialText = string.Empty;
         _sessionCompleteTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _sessionCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _audioChannel = Channel.CreateBounded<AudioChunk>(new BoundedChannelOptions(500)
+        _audioChannel = Channel.CreateUnbounded<AudioChunk>(new UnboundedChannelOptions
         {
-            FullMode = BoundedChannelFullMode.Wait,
             SingleReader = true,
             SingleWriter = false
         });
@@ -94,7 +95,7 @@ public class VolcengineSttProvider : IStreamingSttProvider
     {
         if (_audioChannel == null || _audioChannel.Writer.TryWrite(new AudioChunk(audioData.ToArray(), IsLast: false)) == false)
         {
-            _logger.LogWarning("[Volcengine] Audio channel full or closed, dropping chunk of {Size} bytes.", audioData.Length);
+            _logger.LogWarning("[Volcengine] Audio channel closed, dropping chunk of {Size} bytes.", audioData.Length);
         }
     }
 
@@ -138,6 +139,12 @@ public class VolcengineSttProvider : IStreamingSttProvider
 
         var segments = _results.ToArray();
         var fullText = string.Join("", segments);
+        if (string.IsNullOrWhiteSpace(fullText) && !string.IsNullOrWhiteSpace(_lastPartialText))
+        {
+            fullText = _lastPartialText;
+            _logger.LogWarning("[Volcengine] No final segments received; using last partial transcript ({Length} chars).", fullText.Length);
+        }
+
         _logger.LogInformation("[Volcengine] Session ended. {Length} chars from {Segments} segments.",
             fullText.Length, segments.Length);
 
@@ -477,6 +484,7 @@ public class VolcengineSttProvider : IStreamingSttProvider
 
                 if (!hasDefiniteUtterances && !string.IsNullOrWhiteSpace(resultText))
                 {
+                    _lastPartialText = resultText;
                     _logger.LogDebug("[Volcengine] Partial: {Text}", resultText);
                     PartialResultReceived?.Invoke(this, new SttPartialResult(resultText));
                 }


### PR DESCRIPTION
Fixes Volcengine STT reliability by preventing audio chunks from being dropped during active recording and by falling back to the latest partial transcript when the service does not return final segments.

Summary:
- Use an unbounded audio channel for Volcengine streaming input so normal recording does not drop chunks when the sender falls behind briefly.
- Track the latest partial recognition text and return it as a fallback if no final segments are received.
- Keep the warning path for genuinely closed audio channels.

Validation:
- dotnet build WhisperDesk.sln